### PR TITLE
アーキテクチャを適用/Presentation層をMVPにする

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		E2507075272473D200013FF1 /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2507074272473D200013FF1 /* GitHubRepository.swift */; };
 		E25070772724775F00013FF1 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070762724775F00013FF1 /* User.swift */; };
 		E250707A27247A8A00013FF1 /* GitHubRepositoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250707927247A8900013FF1 /* GitHubRepositoryRepository.swift */; };
-		E250707D27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250707C27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift */; };
+		E250707D27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250707C27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift */; };
 		E250707F27247E1300013FF1 /* APIProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250707E27247E1300013FF1 /* APIProviderFactory.swift */; };
 		E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250708127247E8800013FF1 /* LoggerPlugin.swift */; };
 		E250708627247EF500013FF1 /* URLRequest+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250708527247EF500013FF1 /* URLRequest+.swift */; };
@@ -43,6 +43,9 @@
 		E2507090272492B200013FF1 /* Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250708F272492B200013FF1 /* Presentation.swift */; };
 		E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2507091272494BA00013FF1 /* SplashProtocol.swift */; };
 		E25070942724961100013FF1 /* SplashPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070932724961100013FF1 /* SplashPresenter.swift */; };
+		E250709627249C1500013FF1 /* GitHubRepositorySearchProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */; };
+		E250709827249DE700013FF1 /* GitHubRepositorySearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */; };
+		E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070992724A8AC00013FF1 /* AppContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,7 +97,7 @@
 		E2507074272473D200013FF1 /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
 		E25070762724775F00013FF1 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E250707927247A8900013FF1 /* GitHubRepositoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryRepository.swift; sourceTree = "<group>"; };
-		E250707C27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchGitHubRepositoryUsecase.swift; sourceTree = "<group>"; };
+		E250707C27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchUsecase.swift; sourceTree = "<group>"; };
 		E250707E27247E1300013FF1 /* APIProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProviderFactory.swift; sourceTree = "<group>"; };
 		E250708127247E8800013FF1 /* LoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerPlugin.swift; sourceTree = "<group>"; };
 		E250708527247EF500013FF1 /* URLRequest+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+.swift"; sourceTree = "<group>"; };
@@ -103,6 +106,9 @@
 		E250708F272492B200013FF1 /* Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentation.swift; sourceTree = "<group>"; };
 		E2507091272494BA00013FF1 /* SplashProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashProtocol.swift; sourceTree = "<group>"; };
 		E25070932724961100013FF1 /* SplashPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashPresenter.swift; sourceTree = "<group>"; };
+		E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchProtocol.swift; sourceTree = "<group>"; };
+		E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchPresenter.swift; sourceTree = "<group>"; };
+		E25070992724A8AC00013FF1 /* AppContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContainer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +210,7 @@
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				E250706A27246FB100013FF1 /* AppError.swift */,
 				E250706E2724715800013FF1 /* AppConstant.swift */,
+				E25070992724A8AC00013FF1 /* AppContainer.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -244,6 +251,8 @@
 			children = (
 				E250706027244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard */,
 				BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */,
+				E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */,
+				E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */,
 			);
 			path = GitHubRepositorySearch;
 			sourceTree = "<group>";
@@ -333,7 +342,7 @@
 		E250707B27247B6B00013FF1 /* Usecase */ = {
 			isa = PBXGroup;
 			children = (
-				E250707C27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift */,
+				E250707C27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift */,
 			);
 			path = Usecase;
 			sourceTree = "<group>";
@@ -517,6 +526,7 @@
 				E250708B272488C300013FF1 /* Logger.swift in Sources */,
 				E25070542724487300013FF1 /* SceneRouter.swift in Sources */,
 				E2507075272473D200013FF1 /* GitHubRepository.swift in Sources */,
+				E250709827249DE700013FF1 /* GitHubRepositorySearchPresenter.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift in Sources */,
 				E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */,
 				E25070772724775F00013FF1 /* User.swift in Sources */,
@@ -525,18 +535,20 @@
 				E250706F2724715800013FF1 /* AppConstant.swift in Sources */,
 				E250707F27247E1300013FF1 /* APIProviderFactory.swift in Sources */,
 				E25070942724961100013FF1 /* SplashPresenter.swift in Sources */,
+				E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */,
 				E250706927246F0800013FF1 /* API.swift in Sources */,
 				E25070722724727000013FF1 /* SearchRepositoryRequest.swift in Sources */,
 				E250708627247EF500013FF1 /* URLRequest+.swift in Sources */,
 				E25070562724490A00013FF1 /* RootViewController.swift in Sources */,
 				E2507090272492B200013FF1 /* Presentation.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
-				E250707D27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift in Sources */,
+				E250707D27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift in Sources */,
 				E25070522724476C00013FF1 /* Storyboardable.swift in Sources */,
 				E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */,
 				E250706B27246FB100013FF1 /* AppError.swift in Sources */,
 				E250706D2724712100013FF1 /* APITargetType.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				E250709627249C1500013FF1 /* GitHubRepositorySearchProtocol.swift in Sources */,
 				E250705A2724497E00013FF1 /* MainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
+		BF0A658D244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
-		BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* RepositorySearchViewController.swift */; };
+		BFD945E3244DC5E80012785A /* GitHubRepositorySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */; };
 		BFD945E6244DC5E80012785A /* MainViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E4244DC5E80012785A /* MainViewController.storyboard */; };
 		BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E7244DC5EB0012785A /* Assets.xcassets */; };
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
@@ -22,8 +22,8 @@
 		E250705A2724497E00013FF1 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070592724497E00013FF1 /* MainViewController.swift */; };
 		E250705D27244BE000013FF1 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250705C27244BE000013FF1 /* SplashViewController.swift */; };
 		E250705F27244BED00013FF1 /* SplashViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E250705E27244BED00013FF1 /* SplashViewController.storyboard */; };
-		E250706127244F3C00013FF1 /* RepositorySearchViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E250706027244F3C00013FF1 /* RepositorySearchViewController.storyboard */; };
-		E250706327244FC000013FF1 /* RepositoryDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E250706227244FC000013FF1 /* RepositoryDetailViewController.storyboard */; };
+		E250706127244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E250706027244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard */; };
+		E250706327244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E250706227244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard */; };
 		E250706727246E9700013FF1 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = E250706627246E9700013FF1 /* Moya */; };
 		E250706927246F0800013FF1 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250706827246F0800013FF1 /* API.swift */; };
 		E250706B27246FB100013FF1 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250706A27246FB100013FF1 /* AppError.swift */; };
@@ -63,11 +63,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
+		BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BFD945E0244DC5E80012785A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		BFD945E2244DC5E80012785A /* RepositorySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySearchViewController.swift; sourceTree = "<group>"; };
+		BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchViewController.swift; sourceTree = "<group>"; };
 		BFD945E5244DC5E80012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainViewController.storyboard; sourceTree = "<group>"; };
 		BFD945E7244DC5EB0012785A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BFD945EA244DC5EB0012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -84,8 +84,8 @@
 		E25070592724497E00013FF1 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		E250705C27244BE000013FF1 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		E250705E27244BED00013FF1 /* SplashViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SplashViewController.storyboard; sourceTree = "<group>"; };
-		E250706027244F3C00013FF1 /* RepositorySearchViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RepositorySearchViewController.storyboard; sourceTree = "<group>"; };
-		E250706227244FC000013FF1 /* RepositoryDetailViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RepositoryDetailViewController.storyboard; sourceTree = "<group>"; };
+		E250706027244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GitHubRepositorySearchViewController.storyboard; sourceTree = "<group>"; };
+		E250706227244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GitHubRepositoryDetailViewController.storyboard; sourceTree = "<group>"; };
 		E250706827246F0800013FF1 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		E250706A27246FB100013FF1 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		E250706C2724712100013FF1 /* APITargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITargetType.swift; sourceTree = "<group>"; };
@@ -216,8 +216,8 @@
 				E250704A2724467C00013FF1 /* Root */,
 				E250705B27244BA200013FF1 /* Splash */,
 				E25070502724471600013FF1 /* Main */,
-				E250704C272446B100013FF1 /* RepositorySearch */,
-				E250704D272446C300013FF1 /* RepositoryDetail */,
+				E250704C272446B100013FF1 /* GitHubRepositorySearch */,
+				E250704D272446C300013FF1 /* GitHubRepositoryDetail */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -239,22 +239,22 @@
 			path = Launch;
 			sourceTree = "<group>";
 		};
-		E250704C272446B100013FF1 /* RepositorySearch */ = {
+		E250704C272446B100013FF1 /* GitHubRepositorySearch */ = {
 			isa = PBXGroup;
 			children = (
-				E250706027244F3C00013FF1 /* RepositorySearchViewController.storyboard */,
-				BFD945E2244DC5E80012785A /* RepositorySearchViewController.swift */,
+				E250706027244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard */,
+				BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */,
 			);
-			path = RepositorySearch;
+			path = GitHubRepositorySearch;
 			sourceTree = "<group>";
 		};
-		E250704D272446C300013FF1 /* RepositoryDetail */ = {
+		E250704D272446C300013FF1 /* GitHubRepositoryDetail */ = {
 			isa = PBXGroup;
 			children = (
-				E250706227244FC000013FF1 /* RepositoryDetailViewController.storyboard */,
-				BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */,
+				E250706227244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard */,
+				BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */,
 			);
-			path = RepositoryDetail;
+			path = GitHubRepositoryDetail;
 			sourceTree = "<group>";
 		};
 		E250704E272446E600013FF1 /* Resource */ = {
@@ -487,8 +487,8 @@
 				BFD945E6244DC5E80012785A /* MainViewController.storyboard in Resources */,
 				E25070582724491600013FF1 /* RootViewController.storyboard in Resources */,
 				E250705F27244BED00013FF1 /* SplashViewController.storyboard in Resources */,
-				E250706127244F3C00013FF1 /* RepositorySearchViewController.storyboard in Resources */,
-				E250706327244FC000013FF1 /* RepositoryDetailViewController.storyboard in Resources */,
+				E250706127244F3C00013FF1 /* GitHubRepositorySearchViewController.storyboard in Resources */,
+				E250706327244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -513,11 +513,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */,
+				BFD945E3244DC5E80012785A /* GitHubRepositorySearchViewController.swift in Sources */,
 				E250708B272488C300013FF1 /* Logger.swift in Sources */,
 				E25070542724487300013FF1 /* SceneRouter.swift in Sources */,
 				E2507075272473D200013FF1 /* GitHubRepository.swift in Sources */,
-				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
+				BF0A658D244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift in Sources */,
 				E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */,
 				E25070772724775F00013FF1 /* User.swift in Sources */,
 				E250707A27247A8A00013FF1 /* GitHubRepositoryRepository.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		E250709627249C1500013FF1 /* GitHubRepositorySearchProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */; };
 		E250709827249DE700013FF1 /* GitHubRepositorySearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */; };
 		E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070992724A8AC00013FF1 /* AppContainer.swift */; };
+		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +117,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E286693D2724D7DF00833B6B /* Nuke in Frameworks */,
 				E250706727246E9700013FF1 /* Moya in Frameworks */,
 				E250708E272488E000013FF1 /* SwiftyBeaver in Frameworks */,
 			);
@@ -398,6 +400,7 @@
 			packageProductDependencies = (
 				E250706627246E9700013FF1 /* Moya */,
 				E250708D272488E000013FF1 /* SwiftyBeaver */,
+				E286693C2724D7DF00833B6B /* Nuke */,
 			);
 			productName = iOSEngineerCodeCheck;
 			productReference = BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */;
@@ -898,6 +901,14 @@
 				minimumVersion = 1.9.5;
 			};
 		};
+		E286693B2724D7DF00833B6B /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.5.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -910,6 +921,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E25070892724883200013FF1 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */;
 			productName = SwiftyBeaver;
+		};
+		E286693C2724D7DF00833B6B /* Nuke */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E286693B2724D7DF00833B6B /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = Nuke;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		E2507088272481D400013FF1 /* SearchGitHubRepositoryUsecaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2507087272481D400013FF1 /* SearchGitHubRepositoryUsecaseTests.swift */; };
 		E250708B272488C300013FF1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250708A272488C300013FF1 /* Logger.swift */; };
 		E250708E272488E000013FF1 /* SwiftyBeaver in Frameworks */ = {isa = PBXBuildFile; productRef = E250708D272488E000013FF1 /* SwiftyBeaver */; };
+		E2507090272492B200013FF1 /* Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250708F272492B200013FF1 /* Presentation.swift */; };
+		E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2507091272494BA00013FF1 /* SplashProtocol.swift */; };
+		E25070942724961100013FF1 /* SplashPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070932724961100013FF1 /* SplashPresenter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +100,9 @@
 		E250708527247EF500013FF1 /* URLRequest+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+.swift"; sourceTree = "<group>"; };
 		E2507087272481D400013FF1 /* SearchGitHubRepositoryUsecaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchGitHubRepositoryUsecaseTests.swift; sourceTree = "<group>"; };
 		E250708A272488C300013FF1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		E250708F272492B200013FF1 /* Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentation.swift; sourceTree = "<group>"; };
+		E2507091272494BA00013FF1 /* SplashProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashProtocol.swift; sourceTree = "<group>"; };
+		E25070932724961100013FF1 /* SplashPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashPresenter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				E25070512724476C00013FF1 /* Storyboardable.swift */,
+				E250708F272492B200013FF1 /* Presentation.swift */,
 				E25070492724467500013FF1 /* Screen */,
 			);
 			path = Presentation;
@@ -280,6 +287,8 @@
 			children = (
 				E250705E27244BED00013FF1 /* SplashViewController.storyboard */,
 				E250705C27244BE000013FF1 /* SplashViewController.swift */,
+				E25070932724961100013FF1 /* SplashPresenter.swift */,
+				E2507091272494BA00013FF1 /* SplashProtocol.swift */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
@@ -515,13 +524,16 @@
 				E250705D27244BE000013FF1 /* SplashViewController.swift in Sources */,
 				E250706F2724715800013FF1 /* AppConstant.swift in Sources */,
 				E250707F27247E1300013FF1 /* APIProviderFactory.swift in Sources */,
+				E25070942724961100013FF1 /* SplashPresenter.swift in Sources */,
 				E250706927246F0800013FF1 /* API.swift in Sources */,
 				E25070722724727000013FF1 /* SearchRepositoryRequest.swift in Sources */,
 				E250708627247EF500013FF1 /* URLRequest+.swift in Sources */,
 				E25070562724490A00013FF1 /* RootViewController.swift in Sources */,
+				E2507090272492B200013FF1 /* Presentation.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				E250707D27247BD200013FF1 /* SearchGitHubRepositoryUsecase.swift in Sources */,
 				E25070522724476C00013FF1 /* Storyboardable.swift in Sources */,
+				E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */,
 				E250706B27246FB100013FF1 /* AppError.swift in Sources */,
 				E250706D2724712100013FF1 /* APITargetType.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -46,7 +46,10 @@
 		E250709627249C1500013FF1 /* GitHubRepositorySearchProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */; };
 		E250709827249DE700013FF1 /* GitHubRepositorySearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */; };
 		E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25070992724A8AC00013FF1 /* AppContainer.swift */; };
+		E28669352724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift */; };
+		E28669372724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
+		E28669402724D80F00833B6B /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E286693F2724D80F00833B6B /* UIImageView+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,6 +113,9 @@
 		E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchProtocol.swift; sourceTree = "<group>"; };
 		E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchPresenter.swift; sourceTree = "<group>"; };
 		E25070992724A8AC00013FF1 /* AppContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContainer.swift; sourceTree = "<group>"; };
+		E28669342724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailProtocol.swift; sourceTree = "<group>"; };
+		E28669362724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailPresenter.swift; sourceTree = "<group>"; };
+		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -264,6 +270,8 @@
 			children = (
 				E250706227244FC000013FF1 /* GitHubRepositoryDetailViewController.storyboard */,
 				BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */,
+				E28669362724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift */,
+				E28669342724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift */,
 			);
 			path = GitHubRepositoryDetail;
 			sourceTree = "<group>";
@@ -370,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				E250708527247EF500013FF1 /* URLRequest+.swift */,
+				E286693F2724D80F00833B6B /* UIImageView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -477,6 +486,7 @@
 			packageReferences = (
 				E250706527246E9600013FF1 /* XCRemoteSwiftPackageReference "Moya" */,
 				E25070892724883200013FF1 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
+				E286693B2724D7DF00833B6B /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			productRefGroup = BFD945DC244DC5E80012785A /* Products */;
 			projectDirPath = "";
@@ -533,10 +543,12 @@
 				BF0A658D244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift in Sources */,
 				E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */,
 				E25070772724775F00013FF1 /* User.swift in Sources */,
+				E28669402724D80F00833B6B /* UIImageView+.swift in Sources */,
 				E250707A27247A8A00013FF1 /* GitHubRepositoryRepository.swift in Sources */,
 				E250705D27244BE000013FF1 /* SplashViewController.swift in Sources */,
 				E250706F2724715800013FF1 /* AppConstant.swift in Sources */,
 				E250707F27247E1300013FF1 /* APIProviderFactory.swift in Sources */,
+				E28669372724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift in Sources */,
 				E25070942724961100013FF1 /* SplashPresenter.swift in Sources */,
 				E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */,
 				E250706927246F0800013FF1 /* API.swift in Sources */,
@@ -550,6 +562,7 @@
 				E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */,
 				E250706B27246FB100013FF1 /* AppError.swift in Sources */,
 				E250706D2724712100013FF1 /* APITargetType.swift in Sources */,
+				E28669352724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				E250709627249C1500013FF1 /* GitHubRepositorySearchProtocol.swift in Sources */,
 				E250705A2724497E00013FF1 /* MainViewController.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -155,9 +155,9 @@
 				E25070482724465B00013FF1 /* Application */,
 				E250708327247EC100013FF1 /* Common */,
 				E25070472724465300013FF1 /* Presentation */,
+				E2507073272473C000013FF1 /* Model */,
 				E250707B27247B6B00013FF1 /* Usecase */,
 				E2507078272479D000013FF1 /* Repository */,
-				E2507073272473C000013FF1 /* Model */,
 				E250706427246DE100013FF1 /* Network */,
 			);
 			path = iOSEngineerCodeCheck;

--- a/iOSEngineerCodeCheck/Application/AppContainer.swift
+++ b/iOSEngineerCodeCheck/Application/AppContainer.swift
@@ -1,0 +1,24 @@
+//
+//  AppContainer.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+final class AppContainer {
+
+    // MARK: - Static
+
+    static let shared = AppContainer()
+
+    // MARK: - Property
+
+    let gitHubRepositorySearchUsecase: GitHubReposiotySearchUsecase
+
+    // MARK: - Initializer
+
+    private init() {
+        self.gitHubRepositorySearchUsecase = SearchGitHubRepositoryUsecaseImpl(gitHubRepositoryRepository: GitHubRepositoryRepositoryImpl())
+    }
+}

--- a/iOSEngineerCodeCheck/Application/AppDelegate.swift
+++ b/iOSEngineerCodeCheck/Application/AppDelegate.swift
@@ -18,6 +18,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        setupLogger()
         setupAPI()
 
         return true

--- a/iOSEngineerCodeCheck/Common/Extension/UIImageView+.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIImageView+.swift
@@ -1,0 +1,30 @@
+//
+//  UIImageView+.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+
+import Foundation
+import UIKit
+import Nuke
+
+extension UIImageView {
+
+    func load(_ url: URL?, placeholder: UIImage? = nil, contentMode: UIImageView.ContentMode = .scaleAspectFit) {
+        guard let url = url else { return }
+
+        let contentModes = ImageLoadingOptions.ContentModes(success: contentMode, failure: contentMode, placeholder: contentMode)
+        let options: ImageLoadingOptions = {
+            if let placeholder = placeholder {
+                return ImageLoadingOptions(placeholder: placeholder, contentModes: contentModes)
+            } else {
+                return ImageLoadingOptions(contentModes: contentModes)
+            }
+        }()
+        
+        Nuke.loadImage(with: url, options: options, into: self)
+    }
+}

--- a/iOSEngineerCodeCheck/Model/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/Model/GitHubRepository.swift
@@ -9,6 +9,7 @@
 struct GitHubRepository: Codable {
 
     var fullName: String
+    var language: String?
     var stargazersCount: Int
     var watchersCount: Int
     var forksCount: Int

--- a/iOSEngineerCodeCheck/Model/User.swift
+++ b/iOSEngineerCodeCheck/Model/User.swift
@@ -10,5 +10,5 @@ import Foundation
 
 struct User: Codable {
 
-    var avaterUrl: URL
+    var avatarUrl: URL
 }

--- a/iOSEngineerCodeCheck/Presentation/Presentation.swift
+++ b/iOSEngineerCodeCheck/Presentation/Presentation.swift
@@ -1,0 +1,15 @@
+//
+//  Presentation.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+protocol Presentation: AnyObject {
+
+    func viewDidLoad()
+    func viewWillAppear()
+    func viewDidAppear()
+    func viewDidStop()
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailPresenter.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailPresenter.swift
@@ -1,0 +1,43 @@
+//
+//  GitHubRepositoryDetailPresenter.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+final class GitHubRepositoryDetailPresenter: GitHubRepositoryDetailPresentation {
+
+    // MARK: - Property
+
+    private weak var view: GitHubRepositoryDetailView?
+
+    private let gitHubRepository: GitHubRepository
+
+    // MARK: - Initializer
+
+    init(view: GitHubRepositoryDetailView, gitHubRepository: GitHubRepository) {
+        self.view = view
+        self.gitHubRepository = gitHubRepository
+    }
+
+    // MARK: - Lifecycle
+
+    func viewDidLoad() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.view?.showGitHubRepositoryDetail(gitHubRepository: self.gitHubRepository)
+        }
+    }
+
+    func viewWillAppear() {
+    }
+
+    func viewDidAppear() {
+    }
+
+    func viewDidStop() {
+    }
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailProtocol.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  GitHubRepositoryDetailProtocol.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol GitHubRepositoryDetailView: AnyObject {
+
+    /// GitHubのリポジトリ詳細を表示する
+    ///
+    /// - parameters:
+    ///     - gitHubRepository: GitHubのリポジトリ
+    func showGitHubRepositoryDetail(gitHubRepository: GitHubRepository)
+}
+
+protocol GitHubRepositoryDetailPresentation: Presentation {
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Repository Detail View Controller-->
+        <!--Git Hub Repository Detail View Controller-->
         <scene sceneID="bSc-0X-UXB">
             <objects>
-                <viewController id="gXW-1n-3Xg" customClass="RepositoryDetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="gXW-1n-3Xg" customClass="GitHubRepositoryDetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="s7C-9i-8cX">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.storyboard
@@ -73,6 +73,8 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstItem="pfd-hh-L4e" firstAttribute="leading" secondItem="L11-xg-K9D" secondAttribute="leading" id="YfJ-5E-gCO"/>
+                                    <constraint firstAttribute="trailing" secondItem="pfd-hh-L4e" secondAttribute="trailing" id="YiV-Y0-s4l"/>
                                     <constraint firstItem="jFf-t6-k64" firstAttribute="width" secondItem="pfd-hh-L4e" secondAttribute="width" id="oLt-tc-ZHh"/>
                                 </constraints>
                             </stackView>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
@@ -23,47 +23,57 @@ final class GitHubRepositoryDetailViewController: UIViewController, Storyboardab
     @IBOutlet private weak var issuesLabel: UILabel!
 
     // MARK: - Property
-    
-    var gitHubRepository: GitHubRepository!
+
+    var presenter: GitHubRepositoryDetailPresenter!
 
     // MARK: - Build
 
-    static func build(gitHubRepository: GitHubRepository) -> Self {
-        let viewController = initViewController()
-        viewController.gitHubRepository = gitHubRepository
-
-        return viewController
+    static func build() -> Self {
+        return initViewController()
     }
 
     // MARK: - Lifecycle
         
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupUI()
+
+        presenter.viewDidLoad()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        presenter.viewWillAppear()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        presenter.viewDidAppear()
+    }
+
+    deinit {
+        presenter.viewDidStop()
     }
 
     // MARK: - Private
 
-    private func setupUI() {
+    private func showDetail(gitHubRepository: GitHubRepository) {
         titleLabel.text = gitHubRepository.fullName
-        languageLabel.text = "Written in \(gitHubRepository.language)"
+        languageLabel.text = "Written in \(gitHubRepository.language ?? "")"
         starLabel.text = "\(gitHubRepository.stargazersCount) stars"
         watchersLabel.text = "\(gitHubRepository.watchersCount) watchers"
         forksLabel.text = "\(gitHubRepository.forksCount) forks"
         issuesLabel.text = "\(gitHubRepository.openIssuesCount) open issues"
+        imageView.load(gitHubRepository.owner.avatarUrl)
+    }
+}
 
-        URLSession.shared.dataTask(with: gitHubRepository.owner.avatarUrl) { [weak self] (data, _, error) in
-            guard let self = self else { return }
-            guard let data = data, let image = UIImage(data: data) else {
-                // TODO: エラーハンドリング
-                print(error)
-                return
-            }
+// MARK: - GitHubRepositoryDetailView
 
-            DispatchQueue.main.async {
-                self.imageView.image = image
-            }
-        }.resume()
+extension GitHubRepositoryDetailViewController: GitHubRepositoryDetailView {
+    
+    func showGitHubRepositoryDetail(gitHubRepository: GitHubRepository) {
+        showDetail(gitHubRepository: gitHubRepository)
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
@@ -24,13 +24,13 @@ final class GitHubRepositoryDetailViewController: UIViewController, Storyboardab
 
     // MARK: - Property
     
-    var repository: [String: Any]!
+    var gitHubRepository: GitHubRepository!
 
     // MARK: - Build
 
-    static func build(repository: [String: Any]) -> Self {
+    static func build(gitHubRepository: GitHubRepository) -> Self {
         let viewController = initViewController()
-        viewController.repository = repository
+        viewController.gitHubRepository = gitHubRepository
 
         return viewController
     }
@@ -46,29 +46,24 @@ final class GitHubRepositoryDetailViewController: UIViewController, Storyboardab
     // MARK: - Private
 
     private func setupUI() {
-        titleLabel.text = repository["full_name"] as? String ?? ""
-        languageLabel.text = "Written in \(repository["language"] as? String ?? "")"
-        starLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
-        watchersLabel.text = "\(repository["watchers_count"] as? Int ?? 0) watchers"
-        forksLabel.text = "\(repository["forks_count"] as? Int ?? 0) forks"
-        issuesLabel.text = "\(repository["open_issues_count"] as? Int ?? 0) open issues"
+        titleLabel.text = gitHubRepository.fullName
+        languageLabel.text = "Written in \(gitHubRepository.language)"
+        starLabel.text = "\(gitHubRepository.stargazersCount) stars"
+        watchersLabel.text = "\(gitHubRepository.watchersCount) watchers"
+        forksLabel.text = "\(gitHubRepository.forksCount) forks"
+        issuesLabel.text = "\(gitHubRepository.openIssuesCount) open issues"
 
-        if let owner = repository["owner"] as? [String: Any],
-           let imageURLString = owner["avatar_url"] as? String,
-           let imageURL = URL(string: imageURLString) {
+        URLSession.shared.dataTask(with: gitHubRepository.owner.avatarUrl) { [weak self] (data, _, error) in
+            guard let self = self else { return }
+            guard let data = data, let image = UIImage(data: data) else {
+                // TODO: エラーハンドリング
+                print(error)
+                return
+            }
 
-            URLSession.shared.dataTask(with: imageURL) { [weak self] (data, _, error) in
-                guard let self = self else { return }
-                guard let data = data, let image = UIImage(data: data) else {
-                    // TODO: エラーハンドリング
-                    print(error)
-                    return
-                }
-
-                DispatchQueue.main.async {
-                    self.imageView.image = image
-                }
-            }.resume()
-        }
+            DispatchQueue.main.async {
+                self.imageView.image = image
+            }
+        }.resume()
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositoryDetail/GitHubRepositoryDetailViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class RepositoryDetailViewController: UIViewController, Storyboardable {
+final class GitHubRepositoryDetailViewController: UIViewController, Storyboardable {
 
     // MARK: - Outlet
     

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchPresenter.swift
@@ -1,0 +1,75 @@
+//
+//  GitHubRepositorySearchPresenter.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+final class GitHubRepositorySearchPresenter: GitHubRepositorySearchPresentation {
+
+    // MARK: - Property
+
+    private weak var view: GitHubRepositorySearchView?
+
+    var gitHubRepositoriesCount: Int {
+        return gitHubRepositories.count
+    }
+
+    private let gitHubRepositorySearchUsecase: GitHubReposiotySearchUsecase
+    private var gitHubRepositories: [GitHubRepository] = []
+
+    private var searchTask: Task<Void, Error>?
+
+    // MARK: - Initializer
+
+    init(view: GitHubRepositorySearchView, gitHubRepositorySearchUsecase: GitHubReposiotySearchUsecase) {
+        self.view = view
+        self.gitHubRepositorySearchUsecase = gitHubRepositorySearchUsecase
+    }
+
+    // MARK: - Lifecycle
+
+    func viewDidLoad() {
+    }
+
+    func viewWillAppear() {
+    }
+
+    func viewDidAppear() {
+    }
+
+    func viewDidStop() {
+    }
+
+    func gitHubRepository(at index: Int) -> GitHubRepository {
+        return gitHubRepositories[index]
+    }
+
+    func tableViewDidSelectRow(at index: Int) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.view?.pushToDetailView(gitHubRepository: self.gitHubRepositories[index])
+        }
+    }
+
+    func searchBarSearchButtonDidTap(searchText: String) {
+        searchTask = Task {
+            do {
+                self.gitHubRepositories = try await gitHubRepositorySearchUsecase.searchGitHubRepositories(by: searchText)
+
+                DispatchQueue.main.async {
+                    self.view?.tableViewReloadData()
+                }
+            } catch {
+                Logger.error(error)
+            }
+        }
+    }
+
+    func searchBarSearchTextDidChange() {
+        searchTask?.cancel()
+    }
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchProtocol.swift
@@ -39,7 +39,7 @@ protocol GitHubRepositorySearchPresentation: Presentation {
     /// 検索ボタンが押された
     ///
     /// - parameters:
-    ///     - word: 検索語
+    ///     - searchText: 検索語
     func searchBarSearchButtonDidTap(searchText: String)
 
     /// 検索文字が変更された

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchProtocol.swift
@@ -1,0 +1,48 @@
+//
+//  GitHubRepositorySearchProtocol.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+protocol GitHubRepositorySearchView: AnyObject {
+
+    /// TableViewをリロードする
+    func tableViewReloadData()
+
+    /// 詳細画面に遷移する
+    ///
+    /// - parameters:
+    ///     - repository: 詳細を表示するGitHubのリポジトリ
+    func pushToDetailView(gitHubRepository: GitHubRepository)
+}
+
+protocol GitHubRepositorySearchPresentation: Presentation {
+
+    /// GitHubのリポジトリの数
+    var gitHubRepositoriesCount: Int { get }
+
+    /// 指定されたindexのGitHubRepositoryを返す
+    ///
+    /// - parameters:
+    ///     - index: 指定するindex
+    /// - Returns: 指定されたGitHubRepository
+    func gitHubRepository(at index: Int) -> GitHubRepository
+
+    /// TableViewがselectされた
+    ///
+    /// - parameters:
+    ///     - index: selectされたindex
+    func tableViewDidSelectRow(at index: Int)
+
+    /// 検索ボタンが押された
+    ///
+    /// - parameters:
+    ///     - word: 検索語
+    func searchBarSearchButtonDidTap(searchText: String)
+
+    /// 検索文字が変更された
+    func searchBarSearchTextDidChange()
+}
+

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
@@ -7,10 +7,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Repository Search View Controller-->
+        <!--Git Hub Repository Search View Controller-->
         <scene sceneID="O8t-0O-KV1">
             <objects>
-                <tableViewController id="CTG-1b-a0r" customClass="RepositorySearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="CTG-1b-a0r" customClass="GitHubRepositorySearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
@@ -1,5 +1,5 @@
 //
-//  RepositorySearchViewController.swift
+//  GitHubRepositorySearchViewController.swift
 //  iOSEngineerCodeCheck
 //
 //  Created by 史 翔新 on 2020/04/20.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class RepositorySearchViewController: UITableViewController, Storyboardable {
+final class GitHubRepositorySearchViewController: UITableViewController, Storyboardable {
 
     // MARK: - Outlet
 
@@ -95,7 +95,7 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let detailViewController = RepositoryDetailViewController.build(repository: repositories[indexPath.row])
+        let detailViewController = GitHubRepositoryDetailViewController.build(repository: repositories[indexPath.row])
 
         navigationController?.pushViewController(detailViewController, animated: true)
     }
@@ -103,7 +103,7 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
 // MARK: - UISearchBarDelegate
 
-extension RepositorySearchViewController: UISearchBarDelegate {
+extension GitHubRepositorySearchViewController: UISearchBarDelegate {
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         // 入力を開始したら既存の検索語を削除する

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
@@ -35,6 +35,23 @@ final class GitHubRepositorySearchViewController: UITableViewController, Storybo
         super.viewDidLoad()
 
         title = "検索"
+        presenter.viewDidLoad()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        presenter.viewWillAppear()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        presenter.viewDidAppear()
+    }
+
+    deinit {
+        presenter.viewDidStop()
     }
 
     // MARK: - UITableViewController

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
@@ -68,7 +68,8 @@ extension GitHubRepositorySearchViewController: GitHubRepositorySearchView {
     }
     
     func pushToDetailView(gitHubRepository: GitHubRepository) {
-        let detailViewController = GitHubRepositoryDetailViewController.build(gitHubRepository: gitHubRepository)
+        let detailViewController = GitHubRepositoryDetailViewController.build()
+        detailViewController.presenter = GitHubRepositoryDetailPresenter(view: detailViewController, gitHubRepository: gitHubRepository)
         navigationController?.pushViewController(detailViewController, animated: true)
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/Main/MainViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Main/MainViewController.swift
@@ -22,6 +22,7 @@ final class MainViewController: UINavigationController, Storyboardable {
         super.viewDidLoad()
 
         let viewController = GitHubRepositorySearchViewController.build()
+        viewController.presenter = GitHubRepositorySearchPresenter(view: viewController, gitHubRepositorySearchUsecase: AppContainer.shared.gitHubRepositorySearchUsecase)
         setViewControllers([viewController], animated: false)
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/Main/MainViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Main/MainViewController.swift
@@ -21,7 +21,7 @@ final class MainViewController: UINavigationController, Storyboardable {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewController = RepositorySearchViewController.build()
+        let viewController = GitHubRepositorySearchViewController.build()
         setViewControllers([viewController], animated: false)
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/SceneRouter.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/SceneRouter.swift
@@ -16,7 +16,11 @@ final class SceneRouter {
 
         var viewController: UIViewController {
             switch self {
-            case .splash: return SplashViewController.build()
+            case .splash:
+                let viewController = SplashViewController.build()
+                viewController.presenter = SplashPresenter(view: viewController)
+                return viewController
+                
             case .main: return MainViewController.build()
             }
         }

--- a/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashPresenter.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashPresenter.swift
@@ -1,0 +1,40 @@
+//
+//  SplashPresenter.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+final class SplashPresenter: SplashPresentation {
+
+    // MARK: - Property
+
+    private weak var view: SplashView?
+
+    // MARK: - Initializer
+
+    init(view: SplashView) {
+        self.view = view
+    }
+
+    // MARK: - Lifecycle
+
+    func viewDidLoad() {
+    }
+
+    func viewWillAppear() {
+    }
+
+    // viewDidAppearでしか遷移しない
+    func viewDidAppear() {
+        DispatchQueue.main.async {
+            view?.routeToMain()
+        }
+    }
+
+    func viewDidStop() {
+    }
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashPresenter.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashPresenter.swift
@@ -30,8 +30,8 @@ final class SplashPresenter: SplashPresentation {
 
     // viewDidAppearでしか遷移しない
     func viewDidAppear() {
-        DispatchQueue.main.async {
-            view?.routeToMain()
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.routeToMain()
         }
     }
 

--- a/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashProtocol.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  SplashViewProtocol.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+
+protocol SplashView: AnyObject {
+    func routeToMain()
+}
+
+protocol SplashPresentation: Presentation {
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashProtocol.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashProtocol.swift
@@ -8,6 +8,7 @@
 
 
 protocol SplashView: AnyObject {
+    /// main画面に遷移する
     func routeToMain()
 }
 

--- a/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Splash/SplashViewController.swift
@@ -6,10 +6,13 @@
 //  Copyright © 2021 YUMEMI Inc. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 final class SplashViewController: UIViewController, Storyboardable {
+
+    // MARK: - Property
+
+    var presenter: SplashPresentation!
 
     // MARK: - Build
 
@@ -19,10 +22,34 @@ final class SplashViewController: UIViewController, Storyboardable {
 
     // MARK: - Lifecycle
 
-    // viewDidAppearでないと正常に動作しない
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        presenter.viewDidLoad()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        presenter.viewWillAppear()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        presenter.viewDidAppear()
+    }
+
+    deinit {
+        presenter.viewDidStop()
+    }
+}
+
+// MARK: - SplashView
+
+extension SplashViewController: SplashView {
+
+    func routeToMain() {
         SceneRouter.shared.route(to: .main, animated: true)
     }
 }

--- a/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
+++ b/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
@@ -1,17 +1,17 @@
 //
-//  SearchGitHubRepositoryUsecase.swift
+//  GitHubRepositorySearchUsecase.swift
 //  iOSEngineerCodeCheck
 //
 //  Created by kntk on 2021/10/24.
 //  Copyright © 2021 YUMEMI Inc. All rights reserved.
 //
 
-protocol SearchGitHubReposiotyUsecase {
+protocol GitHubReposiotySearchUsecase {
 
     func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository]
 }
 
-final class SearchGitHubRepositoryUsecaseImpl: SearchGitHubReposiotyUsecase {
+final class SearchGitHubRepositoryUsecaseImpl: GitHubReposiotySearchUsecase {
 
     // MARK: - Property
 

--- a/iOSEngineerCodeCheckTests/SearchGitHubRepositoryUsecaseTests.swift
+++ b/iOSEngineerCodeCheckTests/SearchGitHubRepositoryUsecaseTests.swift
@@ -14,7 +14,7 @@ final class SearchGitHubRepositoryUsecaseTests: XCTestCase {
 
     // MARK: - Property
 
-    private let usecase: SearchGitHubReposiotyUsecase = SearchGitHubRepositoryUsecaseImpl(gitHubRepositoryRepository: GitHubRepositoryRepositoryImpl())
+    private let usecase: GitHubReposiotySearchUsecase = SearchGitHubRepositoryUsecaseImpl(gitHubRepositoryRepository: GitHubRepositoryRepositoryImpl())
 
     override class func setUp() {
         super.setUp()


### PR DESCRIPTION
## 概要

以下2課題に取り組む
- FatVCを回避
    - 本プロジェクトは ViewController が必要以上の責務を抱えており、いわゆる Fat VC 状態です。最低限の責務の切り出しをしてあげましょう。
- アーキテクチャを適用
    - 最近巷では MVC や MVVM などの GUI アーキテクチャから、Redux や VIPER などのアプリアーキテクチャまで様々なアーキテクチャが話題になっています。どれでもいいので本プロジェクトを自分の慣れたアーキテクチャに修正してください。

大規模修正になりそうなので、分割してPRを作成する
- Part1: プロジェクトのディレクトリ構造を修正・Presentation層修正
- Part2: APIの処理をするDomain・Data層を作成する
- **Part3: Presentation層をMVPにする(このPR)**

本PRでは
`ViewController`周りの処理をMVPベースにした上で
API処理を#5 で作成した`Usecase`を用いたものに変更する

また、不完全ではあるが以下の課題も兼ねているものとする。

- 本プロジェクトは様々な原則に違反しています。下記のリストを参考にプログラムをリファクタリングしましょう：
    - DRY 原則
    - CQS 原則
    - 単一責任原則
    - インターフェイス分離の原則
    - 驚き最小の原則

## 実装
`Splash`, `GitHubRepositorySearch`, `GitHubRepositoryDetail`の3画面のみMVP化した。
`Root`, `Main`は現状ルーティング周りの処理しか記述していない かつ 基本的に機能を追加するクラスではないのでMVCで十分だと判断したため。

### 共通
- MVP化する画面では、各ディレクトリに`〇〇Protocol`ファイルを追加し`〇〇View`と`〇〇Presentation`を記述する
    - `viewDidLoad`等の全`〇〇Presentation`に共通する処理を記述した`Presentation`を作成し、`〇〇Presentation`に実装する
- `Presenter`は遷移元で代入するようにする
    - `let viewController = HogeViewController.build(); viewController.presenter = ...`
    - `static func build()`代入してはDIになっておらず、疎結合にしている意味がなくなるから
    - つまり外から代入するようにすれば`Stub`の`Presenter`に変えられるというメリットがある
- `Presenter`から`View`のメソッドを呼び出す場合は`DispatchQueue.main.async`を用いてメインスレッドで呼び出す
- `Presenter`で利用する`Usecase`をシングルトンクラス`AppContainer`で保持、初期化時に用いる

### `Splash`
- 特になし

### `GitHubRepositorySearch`
- `searchBarShouldBeginEditing`で記述されていた「編集開始した時、既にある文字を削除する」機能は
ユーザーの意に反してテキストが消えるのが良くない上、一括で消したいならclearボタンが存在するので不要だと考え削除した

### `GitHubRepositoryDetail`
- 画像取得のためURLから画像を取得するライブラリである[Nuke](https://github.com/kean/Nuke.git)を追加
- `GitHubRepository`に`language`を追加