### PR TITLE
UI をブラッシュアップ/検索画面

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		E28669372724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
 		E28669402724D80F00833B6B /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E286693F2724D80F00833B6B /* UIImageView+.swift */; };
+		E28669442725A64900833B6B /* GitHubRepositoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669422725A64900833B6B /* GitHubRepositoryTableViewCell.swift */; };
+		E28669452725A64900833B6B /* GitHubRepositoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E28669432725A64900833B6B /* GitHubRepositoryTableViewCell.xib */; };
+		E28669472725AE3200833B6B /* NibInstantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669462725AE3200833B6B /* NibInstantiatable.swift */; };
+		E28669492725AEF100833B6B /* UITableView+NibInstantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669482725AEF100833B6B /* UITableView+NibInstantiatable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +120,10 @@
 		E28669342724D52E00833B6B /* GitHubRepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* GitHubRepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		E28669422725A64900833B6B /* GitHubRepositoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryTableViewCell.swift; sourceTree = "<group>"; };
+		E28669432725A64900833B6B /* GitHubRepositoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GitHubRepositoryTableViewCell.xib; sourceTree = "<group>"; };
+		E28669462725AE3200833B6B /* NibInstantiatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NibInstantiatable.swift; sourceTree = "<group>"; };
+		E28669482725AEF100833B6B /* UITableView+NibInstantiatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+NibInstantiatable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -205,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				E25070512724476C00013FF1 /* Storyboardable.swift */,
+				E28669462725AE3200833B6B /* NibInstantiatable.swift */,
 				E250708F272492B200013FF1 /* Presentation.swift */,
 				E25070492724467500013FF1 /* Screen */,
 			);
@@ -261,6 +270,7 @@
 				BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */,
 				E250709727249DE700013FF1 /* GitHubRepositorySearchPresenter.swift */,
 				E250709527249C1500013FF1 /* GitHubRepositorySearchProtocol.swift */,
+				E28669412725A5DC00833B6B /* Component */,
 			);
 			path = GitHubRepositorySearch;
 			sourceTree = "<group>";
@@ -379,6 +389,7 @@
 			children = (
 				E250708527247EF500013FF1 /* URLRequest+.swift */,
 				E286693F2724D80F00833B6B /* UIImageView+.swift */,
+				E28669482725AEF100833B6B /* UITableView+NibInstantiatable.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -388,6 +399,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E28669412725A5DC00833B6B /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				E28669432725A64900833B6B /* GitHubRepositoryTableViewCell.xib */,
+				E28669422725A64900833B6B /* GitHubRepositoryTableViewCell.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -504,6 +524,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E28669452725A64900833B6B /* GitHubRepositoryTableViewCell.xib in Resources */,
 				BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */,
 				BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */,
 				BFD945E6244DC5E80012785A /* MainViewController.storyboard in Resources */,
@@ -539,7 +560,9 @@
 				E250708B272488C300013FF1 /* Logger.swift in Sources */,
 				E25070542724487300013FF1 /* SceneRouter.swift in Sources */,
 				E2507075272473D200013FF1 /* GitHubRepository.swift in Sources */,
+				E28669442725A64900833B6B /* GitHubRepositoryTableViewCell.swift in Sources */,
 				E250709827249DE700013FF1 /* GitHubRepositorySearchPresenter.swift in Sources */,
+				E28669472725AE3200833B6B /* NibInstantiatable.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift in Sources */,
 				E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */,
 				E25070772724775F00013FF1 /* User.swift in Sources */,
@@ -553,6 +576,7 @@
 				E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */,
 				E250706927246F0800013FF1 /* API.swift in Sources */,
 				E25070722724727000013FF1 /* SearchRepositoryRequest.swift in Sources */,
+				E28669492725AEF100833B6B /* UITableView+NibInstantiatable.swift in Sources */,
 				E250708627247EF500013FF1 /* URLRequest+.swift in Sources */,
 				E25070562724490A00013FF1 /* RootViewController.swift in Sources */,
 				E2507090272492B200013FF1 /* Presentation.swift in Sources */,

--- a/iOSEngineerCodeCheck/Common/Extension/UITableView+NibInstantiatable.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UITableView+NibInstantiatable.swift
@@ -1,0 +1,27 @@
+//
+//  UITableView+NibInstantiatable.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/25.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UITableView {
+
+    func register<Cell: NibInstantiatable>(_ cellType: Cell.Type) {
+        self.register(cellType.nib, forCellReuseIdentifier: cellType.identifier)
+    }
+
+    func dequeue<Cell: NibInstantiatable>(_ cellType: Cell.Type, for indexPath: IndexPath) -> Cell {
+        return self.dequeueReusableCell(withIdentifier: cellType.identifier, for: indexPath) as! Cell
+    }
+
+    func dequeue<Cell: NibInstantiatable>(_ cellType: Cell.Type, for indexPath: IndexPath, with dependency: Cell.Dependency) -> Cell {
+        let cell = self.dequeueReusableCell(withIdentifier: cellType.identifier, for: indexPath) as! Cell
+        cell.inject(dependency)
+        
+        return cell
+    }
+}

--- a/iOSEngineerCodeCheck/Model/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/Model/GitHubRepository.swift
@@ -9,11 +9,13 @@
 struct GitHubRepository: Codable {
 
     var fullName: String
+    var name: String
     var language: String?
+    var description: String?
+    var owner: User
     var stargazersCount: Int
     var watchersCount: Int
     var forksCount: Int
     var openIssuesCount: Int
 
-    var owner: User
 }

--- a/iOSEngineerCodeCheck/Model/User.swift
+++ b/iOSEngineerCodeCheck/Model/User.swift
@@ -10,5 +10,6 @@ import Foundation
 
 struct User: Codable {
 
+    var login: String
     var avatarUrl: URL
 }

--- a/iOSEngineerCodeCheck/Presentation/NibInstantiatable.swift
+++ b/iOSEngineerCodeCheck/Presentation/NibInstantiatable.swift
@@ -1,0 +1,35 @@
+//
+//  NibInstantiatable.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/25.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+protocol NibInstantiatable {
+
+    associatedtype Dependency
+
+    func inject(_ dependency: Dependency)
+
+    static var identifier: String { get }
+    static var nibName: String { get }
+    static var nib: UINib { get }
+}
+
+extension NibInstantiatable {
+
+    static var nibName: String {
+        return String(describing: self)
+    }
+
+    static var identifier: String {
+        return nibName
+    }
+
+    static var nib: UINib {
+        return UINib(nibName: nibName, bundle: nil)
+    }
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
@@ -15,10 +15,10 @@ final class GitHubRepositoryTableViewCell: UITableViewCell {
     @IBOutlet private weak var cardView: UIView! {
         didSet {
             cardView.layer.cornerRadius = 10
-            cardView.layer.shadowRadius = 16
+            cardView.layer.shadowRadius = 4
             cardView.layer.shadowOpacity = 1.0
-            cardView.layer.shadowOffset = CGSize(width: 0, height: 5)
-            cardView.layer.shadowColor = #colorLiteral(red: 0.8392156863, green: 0.8392156863, blue: 0.8392156863, alpha: 1)
+            cardView.layer.shadowOffset = CGSize(width: 2, height: 2)
+            cardView.layer.shadowColor = UIColor.systemGray3.cgColor
         }
     }
     @IBOutlet private weak var iconImageView: UIImageView! {

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
@@ -1,0 +1,48 @@
+//
+//  GitHubRepositoryTableViewCell.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/24.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+final class GitHubRepositoryTableViewCell: UITableViewCell {
+
+    // MARK: - Outlet
+
+    @IBOutlet private weak var cardView: UIView! {
+        didSet {
+            cardView.layer.cornerRadius = 10
+            cardView.layer.shadowRadius = 16
+            cardView.layer.shadowOpacity = 1.0
+            cardView.layer.shadowOffset = CGSize(width: 0, height: 5)
+            cardView.layer.shadowColor = #colorLiteral(red: 0.8392156863, green: 0.8392156863, blue: 0.8392156863, alpha: 1)
+        }
+    }
+    @IBOutlet private weak var iconImageView: UIImageView! {
+        didSet {
+            iconImageView.layer.cornerRadius = 14
+            iconImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        }
+    }
+    @IBOutlet private weak var ownerNameLabel: UILabel!
+    @IBOutlet private weak var repositoryNameLabel: UILabel!
+    @IBOutlet private weak var repositoryDescriptionLabel: UILabel!
+
+}
+
+// MARK: - NibInstantiatable
+
+extension GitHubRepositoryTableViewCell: NibInstantiatable {
+
+    typealias Dependency = GitHubRepository
+
+    func inject(_ dependency: GitHubRepository) {
+        iconImageView.load(dependency.owner.avatarUrl, contentMode: .scaleToFill)
+        ownerNameLabel.text = dependency.owner.login
+        repositoryNameLabel.text = dependency.name
+        repositoryDescriptionLabel.text = dependency.description
+    }
+}

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
@@ -45,7 +45,7 @@ extension GitHubRepositoryTableViewCell: NibInstantiatable {
     typealias Dependency = GitHubRepository
 
     func inject(_ dependency: GitHubRepository) {
-        iconImageView.load(dependency.owner.avatarUrl, contentMode: .scaleToFill)
+        iconImageView.load(dependency.owner.avatarUrl, contentMode: .scaleAspectFill)
         ownerNameLabel.text = dependency.owner.login
         repositoryNameLabel.text = dependency.name
         repositoryDescriptionLabel.text = dependency.description

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
@@ -34,7 +34,6 @@ final class GitHubRepositoryTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var starCountLabel: UILabel!
 
-
     @IBOutlet private weak var languageIconImageView: UIImageView!
     @IBOutlet private weak var languageLabel: UILabel!
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.swift
@@ -24,6 +24,7 @@ final class GitHubRepositoryTableViewCell: UITableViewCell {
     @IBOutlet private weak var iconImageView: UIImageView! {
         didSet {
             iconImageView.layer.cornerRadius = 14
+            // 左上と右上の角のみ丸くする
             iconImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         }
     }
@@ -31,6 +32,11 @@ final class GitHubRepositoryTableViewCell: UITableViewCell {
     @IBOutlet private weak var repositoryNameLabel: UILabel!
     @IBOutlet private weak var repositoryDescriptionLabel: UILabel!
 
+    @IBOutlet private weak var starCountLabel: UILabel!
+
+
+    @IBOutlet private weak var languageIconImageView: UIImageView!
+    @IBOutlet private weak var languageLabel: UILabel!
 }
 
 // MARK: - NibInstantiatable
@@ -44,5 +50,13 @@ extension GitHubRepositoryTableViewCell: NibInstantiatable {
         ownerNameLabel.text = dependency.owner.login
         repositoryNameLabel.text = dependency.name
         repositoryDescriptionLabel.text = dependency.description
+        starCountLabel.text = String.localizedStringWithFormat("%d", dependency.stargazersCount)
+        if let language = dependency.language {
+            languageIconImageView.isHidden = false
+            languageLabel.text = language
+        } else {
+            languageIconImageView.isHidden = true
+            languageLabel.text = ""
+        }
     }
 }

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
@@ -10,15 +10,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="504" id="KGk-i7-Jjw" customClass="GitHubRepositoryTableViewCell" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="504"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="528" id="KGk-i7-Jjw" customClass="GitHubRepositoryTableViewCell" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="528"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="504"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="528"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qeh-nG-nxT" userLabel="CardView">
-                        <rect key="frame" x="20" y="16" width="335" height="472"/>
+                        <rect key="frame" x="20" y="16" width="335" height="496"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bsq-dT-Xr5">
                                 <rect key="frame" x="0.0" y="0.0" width="335" height="334"/>
@@ -27,25 +27,68 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="tao-ui-iR3">
-                                <rect key="frame" x="20" y="358" width="295" height="94"/>
+                                <rect key="frame" x="20" y="358" width="295" height="118"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alamofire" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFa-Pz-HYw">
-                                        <rect key="frame" x="0.0" y="0.0" width="295" height="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="295" height="13"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Alamofire" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Oe-5X-Vc1">
-                                        <rect key="frame" x="0.0" y="29" width="295" height="32.5"/>
+                                        <rect key="frame" x="0.0" y="25" width="295" height="32.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Elegant HTTP Networking in Swift" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oc4-P6-zMp">
-                                        <rect key="frame" x="0.0" y="73.5" width="295" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="69.5" width="295" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kUy-Df-ZdF">
+                                        <rect key="frame" x="0.0" y="102" width="141" height="16"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="pCC-kx-BjR">
+                                                <rect key="frame" x="0.0" y="0.0" width="74.5" height="16"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Q1r-44-NXd">
+                                                        <rect key="frame" x="0.0" y="-0.5" width="16" height="16"/>
+                                                        <color key="tintColor" systemColor="secondaryLabelColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="16" id="9IJ-VB-QCp"/>
+                                                            <constraint firstAttribute="width" constant="16" id="YAj-xJ-lDS"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="35,053" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOi-dI-cvw">
+                                                        <rect key="frame" x="20" y="0.0" width="54.5" height="16"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="fMS-TS-haS">
+                                                <rect key="frame" x="82.5" y="0.0" width="58.5" height="16"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pencil" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uc8-zP-Zf5">
+                                                        <rect key="frame" x="0.0" y="2.5" width="16" height="11.5"/>
+                                                        <color key="tintColor" systemColor="secondaryLabelColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="16" id="Ai9-Kn-S6F"/>
+                                                            <constraint firstAttribute="height" constant="16" id="V8o-Qd-zEH"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swift" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Abh-91-qHK">
+                                                        <rect key="frame" x="20" y="0.0" width="38.5" height="16"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="oc4-P6-zMp" firstAttribute="width" secondItem="tao-ui-iR3" secondAttribute="width" id="4N1-Ya-Y9Y"/>
@@ -77,14 +120,19 @@
             <connections>
                 <outlet property="cardView" destination="Qeh-nG-nxT" id="70G-h8-1mw"/>
                 <outlet property="iconImageView" destination="bsq-dT-Xr5" id="QVD-zd-6OA"/>
+                <outlet property="languageIconImageView" destination="uc8-zP-Zf5" id="81b-7x-BVC"/>
+                <outlet property="languageLabel" destination="Abh-91-qHK" id="CqV-Xi-xpA"/>
                 <outlet property="ownerNameLabel" destination="aFa-Pz-HYw" id="7ov-BK-EqL"/>
                 <outlet property="repositoryDescriptionLabel" destination="oc4-P6-zMp" id="idO-Ep-l3o"/>
                 <outlet property="repositoryNameLabel" destination="5Oe-5X-Vc1" id="wZo-tm-gq9"/>
+                <outlet property="starCountLabel" destination="DOi-dI-cvw" id="wCV-yp-iC5"/>
             </connections>
-            <point key="canvasLocation" x="138.40579710144928" y="111.16071428571428"/>
+            <point key="canvasLocation" x="138.40579710144928" y="117.1875"/>
         </tableViewCell>
     </objects>
     <resources>
+        <image name="pencil" catalog="system" width="128" height="113"/>
+        <image name="star" catalog="system" width="128" height="116"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
@@ -109,6 +109,7 @@
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" systemColor="systemGray6Color"/>
                 <constraints>
                     <constraint firstItem="Qeh-nG-nxT" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="SMY-na-GM4"/>
                     <constraint firstAttribute="bottom" secondItem="Qeh-nG-nxT" secondAttribute="bottom" constant="16" id="VRE-2N-ffs"/>
@@ -138,6 +139,9 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
@@ -3,6 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -71,13 +72,14 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="fMS-TS-haS">
                                                 <rect key="frame" x="82.5" y="0.0" width="58.5" height="16"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pencil" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uc8-zP-Zf5">
-                                                        <rect key="frame" x="0.0" y="2.5" width="16" height="11.5"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uc8-zP-Zf5">
+                                                        <rect key="frame" x="0.0" y="0.5" width="16" height="15.5"/>
                                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="16" id="Ai9-Kn-S6F"/>
                                                             <constraint firstAttribute="height" constant="16" id="V8o-Qd-zEH"/>
                                                         </constraints>
+                                                        <imageReference key="image" image="pencil" catalog="system" symbolScale="large"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swift" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Abh-91-qHK">
                                                         <rect key="frame" x="20" y="0.0" width="38.5" height="16"/>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="504" id="KGk-i7-Jjw" customClass="GitHubRepositoryTableViewCell" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="504"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="504"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qeh-nG-nxT" userLabel="CardView">
+                        <rect key="frame" x="20" y="16" width="335" height="472"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bsq-dT-Xr5">
+                                <rect key="frame" x="0.0" y="0.0" width="335" height="334"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="bsq-dT-Xr5" secondAttribute="height" multiplier="1:1" constant="1" id="5iC-u6-HvU"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="tao-ui-iR3">
+                                <rect key="frame" x="20" y="358" width="295" height="94"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alamofire" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFa-Pz-HYw">
+                                        <rect key="frame" x="0.0" y="0.0" width="295" height="17"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Alamofire" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Oe-5X-Vc1">
+                                        <rect key="frame" x="0.0" y="29" width="295" height="32.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Elegant HTTP Networking in Swift" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oc4-P6-zMp">
+                                        <rect key="frame" x="0.0" y="73.5" width="295" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="oc4-P6-zMp" firstAttribute="width" secondItem="tao-ui-iR3" secondAttribute="width" id="4N1-Ya-Y9Y"/>
+                                    <constraint firstItem="aFa-Pz-HYw" firstAttribute="width" secondItem="tao-ui-iR3" secondAttribute="width" id="KwA-dJ-Gti"/>
+                                    <constraint firstItem="5Oe-5X-Vc1" firstAttribute="width" secondItem="tao-ui-iR3" secondAttribute="width" id="Sd1-11-vL6"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="bsq-dT-Xr5" firstAttribute="leading" secondItem="Qeh-nG-nxT" secondAttribute="leading" id="PFp-uW-fzV"/>
+                            <constraint firstItem="tao-ui-iR3" firstAttribute="leading" secondItem="Qeh-nG-nxT" secondAttribute="leading" constant="20" id="cmS-72-sT8"/>
+                            <constraint firstAttribute="bottom" secondItem="tao-ui-iR3" secondAttribute="bottom" constant="20" id="e6u-Jp-gB7"/>
+                            <constraint firstAttribute="trailing" secondItem="tao-ui-iR3" secondAttribute="trailing" constant="20" id="lAt-PO-DGx"/>
+                            <constraint firstItem="tao-ui-iR3" firstAttribute="top" secondItem="bsq-dT-Xr5" secondAttribute="bottom" constant="24" id="lPa-3Q-KSI"/>
+                            <constraint firstItem="bsq-dT-Xr5" firstAttribute="top" secondItem="Qeh-nG-nxT" secondAttribute="top" id="y7i-r6-dCD"/>
+                            <constraint firstAttribute="trailing" secondItem="bsq-dT-Xr5" secondAttribute="trailing" id="yLu-Tb-DTg"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Qeh-nG-nxT" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="SMY-na-GM4"/>
+                    <constraint firstAttribute="bottom" secondItem="Qeh-nG-nxT" secondAttribute="bottom" constant="16" id="VRE-2N-ffs"/>
+                    <constraint firstItem="Qeh-nG-nxT" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="jAc-zA-0kZ"/>
+                    <constraint firstAttribute="trailing" secondItem="Qeh-nG-nxT" secondAttribute="trailing" constant="20" id="sJc-U7-tCy"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="cardView" destination="Qeh-nG-nxT" id="70G-h8-1mw"/>
+                <outlet property="iconImageView" destination="bsq-dT-Xr5" id="QVD-zd-6OA"/>
+                <outlet property="ownerNameLabel" destination="aFa-Pz-HYw" id="7ov-BK-EqL"/>
+                <outlet property="repositoryDescriptionLabel" destination="oc4-P6-zMp" id="idO-Ep-l3o"/>
+                <outlet property="repositoryNameLabel" destination="5Oe-5X-Vc1" id="wZo-tm-gq9"/>
+            </connections>
+            <point key="canvasLocation" x="138.40579710144928" y="111.16071428571428"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/Component/GitHubRepositoryTableViewCell.xib
@@ -111,7 +111,6 @@
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" systemColor="systemGray6Color"/>
                 <constraints>
                     <constraint firstItem="Qeh-nG-nxT" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="SMY-na-GM4"/>
                     <constraint firstAttribute="bottom" secondItem="Qeh-nG-nxT" secondAttribute="bottom" constant="16" id="VRE-2N-ffs"/>
@@ -141,9 +140,6 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
@@ -3,7 +3,6 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,10 +10,9 @@
         <scene sceneID="O8t-0O-KV1">
             <objects>
                 <tableViewController id="CTG-1b-a0r" customClass="GitHubRepositorySearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="400" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="400" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="R5J-Wg-mJB">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -35,9 +33,4 @@
             <point key="canvasLocation" x="-498" y="137"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
@@ -14,7 +14,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="400" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemGray6Color"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="R5J-Wg-mJB">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -36,8 +36,8 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
@@ -11,7 +11,7 @@
         <scene sceneID="O8t-0O-KV1">
             <objects>
                 <tableViewController id="CTG-1b-a0r" customClass="GitHubRepositorySearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="400" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -20,32 +20,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <textInputTraits key="textInputTraits"/>
                         </searchBar>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Repository" textLabel="6h3-3N-kZp" detailTextLabel="l5R-mI-vr8" style="IBUITableViewCellStyleValue1" id="znO-om-j7s">
-                                <rect key="frame" x="0.0" y="88.5" width="414" height="43.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="znO-om-j7s" id="UUC-RD-rpl">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6h3-3N-kZp">
-                                            <rect key="frame" x="20" y="12" width="33" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="l5R-mI-vr8">
-                                            <rect key="frame" x="350" y="12" width="44" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="CTG-1b-a0r" id="1Py-Xd-9Ya"/>
                             <outlet property="delegate" destination="CTG-1b-a0r" id="CoB-GO-n1m"/>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,6 +14,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="400" sectionHeaderHeight="28" sectionFooterHeight="28" id="QTM-13-WvD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemGray6Color"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="R5J-Wg-mJB">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -33,4 +35,9 @@
             <point key="canvasLocation" x="-498" y="137"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/GitHubRepositorySearch/GitHubRepositorySearchViewController.swift
@@ -34,7 +34,9 @@ final class GitHubRepositorySearchViewController: UITableViewController, Storybo
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableView.register(GitHubRepositoryTableViewCell.self)
         title = "検索"
+        
         presenter.viewDidLoad()
     }
 
@@ -61,14 +63,9 @@ final class GitHubRepositorySearchViewController: UITableViewController, Storybo
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "Repository", for: indexPath)
         let gitHubRepository = presenter.gitHubRepository(at: indexPath.row)
 
-        cell.textLabel?.text = gitHubRepository.fullName
-        cell.detailTextLabel?.text = gitHubRepository.language
-        cell.tag = indexPath.row
-
-        return cell
+        return tableView.dequeue(GitHubRepositoryTableViewCell.self, for: indexPath, with: gitHubRepository)
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/iOSEngineerCodeCheck/Presentation/Screen/Main/Base.lproj/MainViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Main/Base.lproj/MainViewController.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -10,9 +11,11 @@
         <scene sceneID="hWi-qa-NBR">
             <objects>
                 <navigationController id="wFt-RI-uk4" customClass="MainViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iRk-f0-Qkc">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="iRk-f0-Qkc">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="barTintColor" systemColor="systemBackgroundColor"/>
                     </navigationBar>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="scZ-hy-tAz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -20,4 +23,9 @@
             <point key="canvasLocation" x="-1417" y="137"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOSEngineerCodeCheck/Presentation/Screen/Main/Base.lproj/MainViewController.storyboard
+++ b/iOSEngineerCodeCheck/Presentation/Screen/Main/Base.lproj/MainViewController.storyboard
@@ -3,7 +3,6 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,11 +10,9 @@
         <scene sceneID="hWi-qa-NBR">
             <objects>
                 <navigationController id="wFt-RI-uk4" customClass="MainViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="iRk-f0-Qkc">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iRk-f0-Qkc">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <color key="barTintColor" systemColor="systemBackgroundColor"/>
                     </navigationBar>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="scZ-hy-tAz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -23,9 +20,4 @@
             <point key="canvasLocation" x="-1417" y="137"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
## 概要

以下の課題に取り組む
- 本アプリの UI は極めてシンプルです。これでも特に問題はありませんが、やはりいまいち映えないです。使いやすさが損なわれない前提で、UI をブラッシュアップしてください。方向性（エレガント、ゴージャス、モダン等）は問いません。また UIKit だけでなく、SwiftUI の導入も OK です。

本PRでは検索画面(`GitHubRepositorySearch`)のブラッシュアップを行う

## 実装
- AppStoreアプリのToday画面やGitHubアプリを参考に作成
- カードスタイル
- 一覧で見ることができる情報
    - 所有者のアイコン
    - 所有者名
    - リポジトリ名
    - 説明(`description`)
    - スター数
    - 言語
- カスタムセル`GitHubRepositoryTableViewCell`とそのXibを作成
    - `XibInstantiatable`: Xibを生成したり、`UITableView`に`register`, `dequeue`しやすいようにするヘルパーprotocol
    - これによって、type-safetyに`UITableView`に`register`, `dequeue`できる
- 表示するのに必要な情報を`GitHubRepository`に追加

<details>
<summary>実装前</summary>

| iPhone13 | iPhoneSE |
| ------ | ------ |
| <img width=300 src="https://user-images.githubusercontent.com/44288050/138608963-f81e57c3-2f5d-4049-8732-5ab577146e9e.png"> | <img width=300 src="https://user-images.githubusercontent.com/44288050/138608970-436ff776-1fa7-41c2-bc70-6ffe880fb87f.png"> | 

</details>

<details>
<summary>実装後</summary>

| iPhone13 | iPhoneSE |
| ------ | ------ |
| <img width=300 src="https://user-images.githubusercontent.com/44288050/138608979-84be80ff-fd3b-4506-9011-02184d02a198.png"> | <img width=300 src="https://user-images.githubusercontent.com/44288050/138608994-2d3b55d6-2471-4b83-9266-bc934b5ab80b.png"> |

</details>

## 備考
- 見た目は良くなっているが、1度に閲覧できる数は少なくなっているので「使いやすさが損なわれない前提で」に違反しているかもしれない...?
- `Nuke`のエラーが発生している
`[Decompressor] Error -17102 decompressing image -- possibly corrupt`
おそらく、Cellの高さが可変で`ImageView`のサイズも可変なので
Nukeで取得中にImageViewの大きさが変更されたことを検知したことのエラーだと考えられる。
ただ、現状レイアウト崩れ等は起こしていないので`Known Issue`として保留