### PR TITLE
検索の挙動をブラッシュアップする

### DIFF
--- a/iOSEngineerCodeCheck/Network/Request/APITargetType.swift
+++ b/iOSEngineerCodeCheck/Network/Request/APITargetType.swift
@@ -24,7 +24,7 @@ extension APITargetType {
     }
 
     var headers: [String: String]? {
-        return [:]
+        return ["Accept": "application/vnd.github.v3+json"]
     }
 
     func decode(from result: Moya.Response) throws -> Response {

--- a/iOSEngineerCodeCheck/Network/Request/SearchRepositoryRequest.swift
+++ b/iOSEngineerCodeCheck/Network/Request/SearchRepositoryRequest.swift
@@ -8,12 +8,32 @@
 
 import Moya
 
+enum GitHubRepositorySortKind {
+    case stars
+    case forks
+    case helpWantedIssues
+    case updated
+    case bestMatch
+
+    var rawValue: String? {
+        switch self {
+        case .stars: return "stars"
+        case .forks: return "forks"
+        case .helpWantedIssues: return "help-wanted-issues"
+        case .updated: return "updated"
+        case .bestMatch: return nil
+        }
+    }
+}
+
 struct SearchGitHubRepositoryResponse: Codable {
     var items: [GitHubRepository]
 }
 
 struct SearchGitHubRepositoryRequest {
+
     var query: String
+    var sort: GitHubRepositorySortKind
 }
 
 extension SearchGitHubRepositoryRequest: APITargetType {
@@ -29,9 +49,13 @@ extension SearchGitHubRepositoryRequest: APITargetType {
     }
 
     var task: Task {
-        let parameters: Parameters = [
+        var parameters: Parameters = [
             "q": query
         ]
+
+        if let sortKind = sort.rawValue {
+            parameters["sort"] = sortKind
+        }
 
         return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
     }

--- a/iOSEngineerCodeCheck/Repository/GitHubRepositoryRepository.swift
+++ b/iOSEngineerCodeCheck/Repository/GitHubRepositoryRepository.swift
@@ -8,13 +8,13 @@
 
 protocol GitHubRepositoryRepository {
 
-    func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository]
+    func searchGitHubRepositories(by word: String, sort: GitHubRepositorySortKind) async throws -> [GitHubRepository]
 }
 
 
 final class GitHubRepositoryRepositoryImpl: GitHubRepositoryRepository {
 
-    func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository] {
-        return try await API.shared.call(SearchGitHubRepositoryRequest(query: word)).items
+    func searchGitHubRepositories(by word: String, sort: GitHubRepositorySortKind) async throws -> [GitHubRepository] {
+        return try await API.shared.call(SearchGitHubRepositoryRequest(query: word, sort: sort)).items
     }
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/GitHubRepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/GitHubRepositoryDetailViewController.swift
@@ -41,6 +41,7 @@ final class RepositoryDetailViewController: VStackViewController, Storyboardable
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationController?.navigationBar.prefersLargeTitles = false
         title = gitHubRepository.name
     }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -60,12 +60,20 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
             do {
                 self.gitHubRepositories = try await gitHubRepositorySearchUsecase.searchGitHubRepositories(by: searchText)
 
-                DispatchQueue.main.async {
-                    self.view?.tableViewReloadData()
+                DispatchQueue.main.async { [weak self] in
+                    self?.view?.tableViewReloadData()
                 }
             } catch {
                 Logger.error(error)
             }
+        }
+    }
+
+    func searchBarCancelButtonDidTap() {
+        searchTask?.cancel()
+        gitHubRepositories = []
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.tableViewReloadData()
         }
     }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -62,6 +62,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
 
                 DispatchQueue.main.async { [weak self] in
                     self?.view?.tableViewReloadData()
+                    self?.view?.tableViewScrollToTop(animated: false)
                 }
             } catch {
                 Logger.error(error)

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -21,6 +21,9 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     private let gitHubRepositorySearchUsecase: GitHubReposiotySearchUsecase
     private var gitHubRepositories: [GitHubRepository] = []
 
+    // 非検索状態で表示される「おすすめ」的な立ち位置のリポジトリ一覧
+    private var initialGitHubRepositories: [GitHubRepository]?
+
     private var searchTask: Task<Void, Error>?
 
     // MARK: - Initializer
@@ -33,6 +36,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     // MARK: - Lifecycle
 
     func viewDidLoad() {
+        setInitialGitHubRepositories()
     }
 
     func viewWillAppear() {
@@ -72,13 +76,38 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
 
     func searchBarCancelButtonDidTap() {
         searchTask?.cancel()
-        gitHubRepositories = []
-        DispatchQueue.main.async { [weak self] in
-            self?.view?.tableViewReloadData()
-        }
+        setInitialGitHubRepositories()
     }
 
     func searchBarSearchTextDidChange() {
         searchTask?.cancel()
+    }
+
+    // MARK: - Private
+
+    private func setInitialGitHubRepositories() {
+        // 既に取得してある場合は使い回す
+        if let initialGitHubRepositories = initialGitHubRepositories {
+            gitHubRepositories = initialGitHubRepositories
+            DispatchQueue.main.async { [weak self] in
+                self?.view?.tableViewReloadData()
+                self?.view?.tableViewScrollToTop(animated: false)
+            }
+        } else {
+            searchTask = Task {
+                do {
+                    let initialGitHubRepositories = try await gitHubRepositorySearchUsecase.getTrendingGitHubRepositories()
+                    self.initialGitHubRepositories = initialGitHubRepositories
+                    gitHubRepositories = initialGitHubRepositories
+
+                    DispatchQueue.main.async { [weak self] in
+                        self?.view?.tableViewReloadData()
+                        self?.view?.tableViewScrollToTop(animated: false)
+                    }
+                } catch {
+                    Logger.error(error)
+                }
+            }
+        }
     }
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -8,6 +8,9 @@
 
 protocol RepositorySearchView: AnyObject {
 
+    /// TableViewを最上部までスクロールする
+    func tableViewScrollToTop(animated: Bool)
+
     /// TableViewをリロードする
     func tableViewReloadData()
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -42,6 +42,9 @@ protocol RepositorySearchPresentation: Presentation {
     ///     - searchText: 検索語
     func searchBarSearchButtonDidTap(searchText: String)
 
+    /// キャンセルボタンが押された
+    func searchBarCancelButtonDidTap()
+
     /// 検索文字が変更された
     func searchBarSearchTextDidChange()
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.storyboard
@@ -15,20 +15,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <searchBar key="tableHeaderView" contentMode="redraw" id="R5J-Wg-mJB">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </searchBar>
                         <connections>
                             <outlet property="dataSource" destination="CTG-1b-a0r" id="1Py-Xd-9Ya"/>
                             <outlet property="delegate" destination="CTG-1b-a0r" id="CoB-GO-n1m"/>
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="bjR-OC-Rbr"/>
-                    <connections>
-                        <outlet property="searchBar" destination="R5J-Wg-mJB" id="OGS-Ln-fqb"/>
-                    </connections>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1ix-Gf-vNA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -36,13 +36,14 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
         title = "検索"
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
-        navigationController?.navigationBar.prefersLargeTitles = true
         
         presenter.viewDidLoad()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        navigationController?.navigationBar.prefersLargeTitles = true
 
         presenter.viewWillAppear()
     }
@@ -109,5 +110,9 @@ extension RepositorySearchViewController: UISearchBarDelegate {
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         presenter.searchBarSearchButtonDidTap(searchText: searchBar.text ?? "")
+    }
+
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        presenter.searchBarCancelButtonDidTap()
     }
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -10,18 +10,16 @@ import UIKit
 
 final class RepositorySearchViewController: UITableViewController, Storyboardable {
 
-    // MARK: - Outlet
-
-    @IBOutlet private weak var searchBar: UISearchBar! {
-        didSet {
-            searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
-            searchBar.delegate = self
-        }
-    }
-
     // MARK: - Property
 
     var presenter: RepositorySearchPresentation!
+
+    private lazy var searchController: UISearchController = {
+        let searchController = UISearchController()
+        searchController.searchBar.delegate = self
+
+        return searchController
+    }()
 
     // MARK: - Build
 
@@ -36,6 +34,9 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
         tableView.register(RepositoryTableViewCell.self)
         title = "検索"
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        navigationController?.navigationBar.prefersLargeTitles = true
         
         presenter.viewDidLoad()
     }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -17,6 +17,7 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
     private lazy var searchController: UISearchController = {
         let searchController = UISearchController()
         searchController.searchBar.delegate = self
+        searchController.searchBar.placeholder = "GitHubのリポジトリを検索"
 
         return searchController
     }()

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -80,6 +80,12 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
 extension RepositorySearchViewController: RepositorySearchView {
 
+    func tableViewScrollToTop(animated: Bool) {
+        if tableView.numberOfRows(inSection: 0) != 0 {
+            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: animated)
+        }
+    }
+
     func tableViewReloadData() {
         self.tableView.reloadData()
     }

--- a/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
+++ b/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
@@ -9,6 +9,8 @@
 protocol GitHubReposiotySearchUsecase {
 
     func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository]
+
+    func getTrendingGitHubRepositories() async throws -> [GitHubRepository]
 }
 
 final class GitHubRepositorySearchUsecaseImpl: GitHubReposiotySearchUsecase {
@@ -26,6 +28,13 @@ final class GitHubRepositorySearchUsecaseImpl: GitHubReposiotySearchUsecase {
     // MARK: - Internal
 
     func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository] {
-        return try await gitHubRepositoryRepository.searchGitHubRepositories(by: word)
+        return try await gitHubRepositoryRepository.searchGitHubRepositories(by: word, sort: .bestMatch)
+    }
+
+    // FIXME: トレンドAPI
+    // トレンド的な良さげなレポジトリを返してくれるAPIがほしかったが、
+    // なかったので現状はSwiftで検索したもので代用中
+    func getTrendingGitHubRepositories() async throws -> [GitHubRepository] {
+        return try await gitHubRepositoryRepository.searchGitHubRepositories(by: "Swift", sort: .stars)
     }
 }


### PR DESCRIPTION
## 概要
- 検索の挙動を修正する

## 実装
- `UISerchBar`から`UISearchControll`に変更
    - より多機能で使いやすいため
    - `UISearchControl.UISerchBar.delegate`を利用するので既存の`UISearchBarDelegate`の処理は使いまわせた
- 一覧の`NavigationBar`を`LargeTitle`にする
- 検索結果が更新された時、一番上部へとスクロールするようにする
- 非検索状態では「おすすめ」的なリポジトリ一覧を表示するようにする
    - `/trending`のようなAPIがなかったので、現在は検索に「Swift」を入れて代用
        - この代用トレンドは`sort`が`start`になっている
    - このおすすめは初回取得をキャッシュしておき、キャンセルボタンを押した後すぐに表示できるようにする
- 検索APIのクエリのsortを設定できるように追加
- APIのヘッダに`application/vnd.github.v3+json`をつけるように修正

![Oct-26-2021 21-43-49](https://user-images.githubusercontent.com/44288050/138882753-b00a9ac6-6774-4fa1-9d11-3048e385a2fa.gif)


