### PR TITLE
検索画面で検索結果が空だった場合に結果がないことを表示する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		E27087D22727CB0100AE7223 /* GitHubRepositoryReadmeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D12727CB0100AE7223 /* GitHubRepositoryReadmeRepository.swift */; };
 		E27087D42727CDEE00AE7223 /* GitHubRepositoryDetailUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D32727CDEE00AE7223 /* GitHubRepositoryDetailUsecase.swift */; };
 		E27087D62727E7E000AE7223 /* WebViewShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D52727E7E000AE7223 /* WebViewShowable.swift */; };
+		E27087DA272847DD00AE7223 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D9272847DD00AE7223 /* EmptyViewController.swift */; };
+		E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E27087DC2728483600AE7223 /* EmptyViewController.storyboard */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -147,6 +149,8 @@
 		E27087D12727CB0100AE7223 /* GitHubRepositoryReadmeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryReadmeRepository.swift; sourceTree = "<group>"; };
 		E27087D32727CDEE00AE7223 /* GitHubRepositoryDetailUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailUsecase.swift; sourceTree = "<group>"; };
 		E27087D52727E7E000AE7223 /* WebViewShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewShowable.swift; sourceTree = "<group>"; };
+		E27087D9272847DD00AE7223 /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
+		E27087DC2728483600AE7223 /* EmptyViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EmptyViewController.storyboard; sourceTree = "<group>"; };
 		E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -468,6 +472,15 @@
 			path = Markdown;
 			sourceTree = "<group>";
 		};
+		E27087DB2728482100AE7223 /* Empty */ = {
+			isa = PBXGroup;
+			children = (
+				E27087DC2728483600AE7223 /* EmptyViewController.storyboard */,
+				E27087D9272847DD00AE7223 /* EmptyViewController.swift */,
+			);
+			path = Empty;
+			sourceTree = "<group>";
+		};
 		E28669412725A5DC00833B6B /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -480,6 +493,7 @@
 		E286694A2725F62600833B6B /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				E27087DB2728482100AE7223 /* Empty */,
 				E286694B2725F63E00833B6B /* VStackViewController.swift */,
 			);
 			path = Common;
@@ -633,6 +647,7 @@
 				E27087BD2726894E00AE7223 /* RepositoryDetailReadmeViewController.storyboard in Resources */,
 				E27087CA27276B4600AE7223 /* mdbase.html in Resources */,
 				E27087C72727683100AE7223 /* github-markdown.css in Resources */,
+				E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */,
 				E250706127244F3C00013FF1 /* RepositorySearchViewController.storyboard in Resources */,
 				E250706327244FC000013FF1 /* RepositoryDetailViewController.storyboard in Resources */,
 			);
@@ -677,6 +692,7 @@
 				E250705D27244BE000013FF1 /* SplashViewController.swift in Sources */,
 				E250706F2724715800013FF1 /* AppConstant.swift in Sources */,
 				E250707F27247E1300013FF1 /* APIProviderFactory.swift in Sources */,
+				E27087DA272847DD00AE7223 /* EmptyViewController.swift in Sources */,
 				E286694E2725F68B00833B6B /* UIView+Constraint.swift in Sources */,
 				E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */,
 				E25070942724961100013FF1 /* SplashPresenter.swift in Sources */,

--- a/iOSEngineerCodeCheck/UI/Common/Empty/EmptyViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Common/Empty/EmptyViewController.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Empty View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="EmptyViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="391"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データはありません" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8mI-Qp-ljW">
+                                <rect key="frame" x="124.5" y="185" width="165.5" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="8mI-Qp-ljW" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="Mxd-td-PLv"/>
+                            <constraint firstItem="8mI-Qp-ljW" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="xaM-iS-0WE"/>
+                        </constraints>
+                    </view>
+                    <size key="freeformSize" width="414" height="391"/>
+                    <connections>
+                        <outlet property="titleLabel" destination="8mI-Qp-ljW" id="TFE-Dv-biL"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-7.2463768115942031" y="-60.602678571428569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOSEngineerCodeCheck/UI/Common/Empty/EmptyViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Common/Empty/EmptyViewController.swift
@@ -1,0 +1,32 @@
+//
+//  EmptyViewController.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/26.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+final class EmptyViewController: UIViewController, Storyboardable {
+
+    // MARK: - Outlet
+
+    @IBOutlet private weak var titleLabel: UILabel! {
+        didSet {
+            self.titleLabel.text = emptyTitle
+        }
+    }
+
+    // MARK: - Property
+
+    private var emptyTitle: String!
+
+    // MARK: - Build
+
+    static func build(emptyTitle: String) -> Self {
+        let viewControlelr = initViewController()
+        viewControlelr.emptyTitle = emptyTitle
+        return viewControlelr
+    }
+}

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -14,6 +14,8 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
 
     private weak var view: RepositorySearchView?
 
+    var showEmptyView = false
+
     var gitHubRepositoriesCount: Int {
         return gitHubRepositories.count
     }
@@ -63,6 +65,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
         searchTask = Task {
             do {
                 self.gitHubRepositories = try await gitHubRepositorySearchUsecase.searchGitHubRepositories(by: searchText)
+                showEmptyView = self.gitHubRepositories.isEmpty
 
                 DispatchQueue.main.async { [weak self] in
                     self?.view?.tableViewReloadData()
@@ -89,6 +92,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
         // 既に取得してある場合は使い回す
         if let initialGitHubRepositories = initialGitHubRepositories {
             gitHubRepositories = initialGitHubRepositories
+            showEmptyView = gitHubRepositories.isEmpty
             DispatchQueue.main.async { [weak self] in
                 self?.view?.tableViewReloadData()
                 self?.view?.tableViewScrollToTop(animated: false)
@@ -99,6 +103,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                     let initialGitHubRepositories = try await gitHubRepositorySearchUsecase.getTrendingGitHubRepositories()
                     self.initialGitHubRepositories = initialGitHubRepositories
                     gitHubRepositories = initialGitHubRepositories
+                    showEmptyView = gitHubRepositories.isEmpty
 
                     DispatchQueue.main.async { [weak self] in
                         self?.view?.tableViewReloadData()

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -23,6 +23,9 @@ protocol RepositorySearchView: AnyObject {
 
 protocol RepositorySearchPresentation: Presentation {
 
+    /// EmptyViewを表示するかどうか
+    var showEmptyView: Bool { get }
+
     /// GitHubのリポジトリの数
     var gitHubRepositoriesCount: Int { get }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -22,6 +22,8 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
         return searchController
     }()
 
+    private lazy var emptyViewController = EmptyViewController.build(emptyTitle: "リポジトリがありません")
+
     // MARK: - Build
 
     static func build() -> Self {
@@ -70,9 +72,17 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
         return tableView.dequeue(RepositoryTableViewCell.self, for: indexPath, with: gitHubRepository)
     }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return presenter.showEmptyView ? emptyViewController.view : nil
+    }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         presenter.tableViewDidSelectRow(at: indexPath.row)
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return presenter.showEmptyView ? tableView.bounds.height : CGFloat.leastNormalMagnitude
     }
 }
 


### PR DESCRIPTION
## 概要
- 検索画面で検索結果が空だった場合、結果が存在しないことを表示する

## 実装
- `EmptyViewControlelr`を追加
    - ラベルが1個置いてあるだけのViewController、`EmptyView`として使う
- `RepositorySearchPresentation`に`showEmptyView: Bool`を追加
    - このパラメーターを見てtableviewヘッダーに`EmptyView`を追加しTableView全体に広げる
    - Presenterからこの値を変更する(主にAPI終了後に更新)

| light | dark |
| ------ | ------ |
|  ![Simulator Screen Shot - iPhone 13 - 2021-10-27 at 00 12 12](https://user-images.githubusercontent.com/44288050/138911357-88a54ee2-ca24-4049-a7f7-976f86b7309f.png) |  ![Simulator Screen Shot - iPhone 13 - 2021-10-27 at 00 22 16](https://user-images.githubusercontent.com/44288050/138911396-55de0faa-a293-4a19-b03d-e1e813882e82.png) |
