### PR TITLE
ロード中表示を追加する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		E27087D62727E7E000AE7223 /* WebViewShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D52727E7E000AE7223 /* WebViewShowable.swift */; };
 		E27087DA272847DD00AE7223 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D9272847DD00AE7223 /* EmptyViewController.swift */; };
 		E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E27087DC2728483600AE7223 /* EmptyViewController.storyboard */; };
+		E271715E2728C05D00E3C1ED /* UIView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -151,6 +152,7 @@
 		E27087D52727E7E000AE7223 /* WebViewShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewShowable.swift; sourceTree = "<group>"; };
 		E27087D9272847DD00AE7223 /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
 		E27087DC2728483600AE7223 /* EmptyViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EmptyViewController.storyboard; sourceTree = "<group>"; };
+		E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+LoadingIndicator.swift"; sourceTree = "<group>"; };
 		E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				E286693F2724D80F00833B6B /* UIImageView+.swift */,
 				E28669482725AEF100833B6B /* UITableView+NibInstantiatable.swift */,
 				E286694D2725F68B00833B6B /* UIView+Constraint.swift */,
+				E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -700,6 +703,7 @@
 				E250709A2724A8AC00013FF1 /* AppContainer.swift in Sources */,
 				E250706927246F0800013FF1 /* API.swift in Sources */,
 				E286694C2725F63E00833B6B /* VStackViewController.swift in Sources */,
+				E271715E2728C05D00E3C1ED /* UIView+LoadingIndicator.swift in Sources */,
 				E27087D22727CB0100AE7223 /* GitHubRepositoryReadmeRepository.swift in Sources */,
 				E25070722724727000013FF1 /* SearchRepositoryRequest.swift in Sources */,
 				E28669492725AEF100833B6B /* UITableView+NibInstantiatable.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		E27087DA272847DD00AE7223 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27087D9272847DD00AE7223 /* EmptyViewController.swift */; };
 		E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E27087DC2728483600AE7223 /* EmptyViewController.storyboard */; };
 		E271715E2728C05D00E3C1ED /* UIView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */; };
+		E27171602728E93600E3C1ED /* ispinner.css in Resources */ = {isa = PBXBuildFile; fileRef = E271715F2728E93600E3C1ED /* ispinner.css */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -153,6 +154,7 @@
 		E27087D9272847DD00AE7223 /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
 		E27087DC2728483600AE7223 /* EmptyViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EmptyViewController.storyboard; sourceTree = "<group>"; };
 		E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+LoadingIndicator.swift"; sourceTree = "<group>"; };
+		E271715F2728E93600E3C1ED /* ispinner.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = ispinner.css; sourceTree = "<group>"; };
 		E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -469,6 +471,7 @@
 			isa = PBXGroup;
 			children = (
 				E27087C42727682C00AE7223 /* marked.js */,
+				E271715F2728E93600E3C1ED /* ispinner.css */,
 				E27087C62727683100AE7223 /* github-markdown.css */,
 				E27087C92727697B00AE7223 /* mdbase.html */,
 			);
@@ -649,6 +652,7 @@
 				E28669582725FEE400833B6B /* RepositoryDetailCountViewController.storyboard in Resources */,
 				E27087BD2726894E00AE7223 /* RepositoryDetailReadmeViewController.storyboard in Resources */,
 				E27087CA27276B4600AE7223 /* mdbase.html in Resources */,
+				E27171602728E93600E3C1ED /* ispinner.css in Resources */,
 				E27087C72727683100AE7223 /* github-markdown.css in Resources */,
 				E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */,
 				E250706127244F3C00013FF1 /* RepositorySearchViewController.storyboard in Resources */,

--- a/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
@@ -27,7 +27,7 @@ extension UIView {
         }
     }
 
-    func startLoading() {
+    func showLoading() {
         if let addedIndicatorView = getAddedIndicatorView() {
             addedIndicatorView.isHidden = false
             isUserInteractionEnabled = false
@@ -44,7 +44,7 @@ extension UIView {
         }
     }
 
-    func stopLoading() {
+    func hideLoading() {
         if let addedIndicatorView = getAddedIndicatorView() {
             isUserInteractionEnabled = true
             addedIndicatorView.stopAnimating()

--- a/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
@@ -1,0 +1,65 @@
+//
+//  UIView+LoadingIndicator.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/27.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+enum IndicatorViewKey {
+    static let tag = 100
+}
+
+extension UIView {
+
+    var indicatorView: UIActivityIndicatorView {
+        get {
+            let indicatorView = UIActivityIndicatorView()
+            indicatorView.style = .large
+            indicatorView.color = .systemGray
+            indicatorView.backgroundColor = .clear
+            indicatorView.frame.size.height = 50
+            indicatorView.tag = IndicatorViewKey.tag
+
+            return indicatorView
+        }
+    }
+
+    func startLoading() {
+        if let addedIndicatorView = getAddedIndicatorView() {
+            addedIndicatorView.isHidden = false
+            isUserInteractionEnabled = false
+            addedIndicatorView.startAnimating()
+        } else {
+            let indicatorView = indicatorView
+            indicatorView.translatesAutoresizingMaskIntoConstraints = false
+            indicatorView.hidesWhenStopped = true
+
+            self.addSubview(indicatorView, constraints: .center())
+
+            isUserInteractionEnabled = false
+            indicatorView.startAnimating()
+        }
+    }
+
+    func stopLoading() {
+        if let addedIndicatorView = getAddedIndicatorView() {
+            isUserInteractionEnabled = true
+            addedIndicatorView.stopAnimating()
+            addedIndicatorView.isHidden = true
+        }
+    }
+
+    private func getAddedIndicatorView() -> UIActivityIndicatorView? {
+        for subview in subviews {
+            if let indicatorView = subview as? UIActivityIndicatorView, indicatorView.tag == IndicatorViewKey.tag {
+                return indicatorView
+            }
+        }
+
+        return nil
+    }
+}
+

--- a/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIView+LoadingIndicator.swift
@@ -27,10 +27,14 @@ extension UIView {
         }
     }
 
-    func showLoading() {
+    func showLoading(disableUserIteraction: Bool = true) {
         if let addedIndicatorView = getAddedIndicatorView() {
             addedIndicatorView.isHidden = false
-            isUserInteractionEnabled = false
+
+            if disableUserIteraction {
+                isUserInteractionEnabled = false
+            }
+
             addedIndicatorView.startAnimating()
         } else {
             let indicatorView = indicatorView
@@ -39,7 +43,10 @@ extension UIView {
 
             self.addSubview(indicatorView, constraints: .center())
 
-            isUserInteractionEnabled = false
+            if disableUserIteraction {
+                isUserInteractionEnabled = false
+            }
+
             indicatorView.startAnimating()
         }
     }

--- a/iOSEngineerCodeCheck/Resource/Markdown/ispinner.css
+++ b/iOSEngineerCodeCheck/Resource/Markdown/ispinner.css
@@ -1,0 +1,73 @@
+/*https://github.com/swordray/ispinner*/
+
+.ispinner {
+  position: relative;
+  width: 20px;
+  height: 20px; }
+  .ispinner .ispinner-blade {
+    position: absolute;
+    top: 6.5px;
+    left: 8.5px;
+    width: 2.5px;
+    height: 6.5px;
+    background-color: #8e8e93;
+    border-radius: 1.25px;
+    animation: iSpinnerBlade 1s linear infinite;
+    will-change: opacity; }
+    .ispinner .ispinner-blade:nth-child(1) {
+      transform: rotate(45deg) translateY(-6.5px);
+      animation-delay: -1.625s; }
+    .ispinner .ispinner-blade:nth-child(2) {
+      transform: rotate(90deg) translateY(-6.5px);
+      animation-delay: -1.5s; }
+    .ispinner .ispinner-blade:nth-child(3) {
+      transform: rotate(135deg) translateY(-6.5px);
+      animation-delay: -1.375s; }
+    .ispinner .ispinner-blade:nth-child(4) {
+      transform: rotate(180deg) translateY(-6.5px);
+      animation-delay: -1.25s; }
+    .ispinner .ispinner-blade:nth-child(5) {
+      transform: rotate(225deg) translateY(-6.5px);
+      animation-delay: -1.125s; }
+    .ispinner .ispinner-blade:nth-child(6) {
+      transform: rotate(270deg) translateY(-6.5px);
+      animation-delay: -1s; }
+    .ispinner .ispinner-blade:nth-child(7) {
+      transform: rotate(315deg) translateY(-6.5px);
+      animation-delay: -0.875s; }
+    .ispinner .ispinner-blade:nth-child(8) {
+      transform: rotate(360deg) translateY(-6.5px);
+      animation-delay: -0.75s; }
+  .ispinner.ispinner-large {
+    width: 35px;
+    height: 35px; }
+    .ispinner.ispinner-large .ispinner-blade {
+      top: 11.5px;
+      left: 15px;
+      width: 5px;
+      height: 12px;
+      border-radius: 2.5px; }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(1) {
+        transform: rotate(45deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(2) {
+        transform: rotate(90deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(3) {
+        transform: rotate(135deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(4) {
+        transform: rotate(180deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(5) {
+        transform: rotate(225deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(6) {
+        transform: rotate(270deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(7) {
+        transform: rotate(315deg) translateY(-11.5px); }
+      .ispinner.ispinner-large .ispinner-blade:nth-child(8) {
+        transform: rotate(360deg) translateY(-11.5px); }
+
+@keyframes iSpinnerBlade {
+  0% {
+    opacity: 0.85; }
+  50% {
+    opacity: 0.25; }
+  100% {
+    opacity: 0.25; } }

--- a/iOSEngineerCodeCheck/Resource/Markdown/mdbase.html
+++ b/iOSEngineerCodeCheck/Resource/Markdown/mdbase.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script type="text/javascript" src="./marked.js"></script>
   <link rel="stylesheet" href="./github-markdown.css">
+  <link href="ispinner.css" rel="stylesheet">
   <script>
   function insert(html) {
     marked.setOptions({
@@ -20,7 +21,20 @@
 
 <body>
   <article class="markdown-body">
-    <div id="content" />
+    <div id="content">
+      <div style="height: 100px;display: flex;align-items: center;justify-content: center;">
+        <div class="ispinner ispinner-large">
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+          <div class="ispinner-blade"></div>
+        </div>
+      </div>
+    </dvi>
   </article>
 </body>
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.storyboard
@@ -13,14 +13,14 @@
             <objects>
                 <viewController id="Y6W-OH-hqX" customClass="RepositoryDetailReadmeViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="444"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="144"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Ps-Fr-Qfz">
-                                <rect key="frame" x="0.0" y="44" width="414" height="400"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="100"/>
                                 <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="400" id="AHG-uU-f0d"/>
+                                    <constraint firstAttribute="height" constant="100" id="AHG-uU-f0d"/>
                                 </constraints>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -48,7 +48,7 @@
                             <constraint firstItem="9Ps-Fr-Qfz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="vgy-L6-Vlw"/>
                         </constraints>
                     </view>
-                    <size key="freeformSize" width="414" height="444"/>
+                    <size key="freeformSize" width="414" height="144"/>
                     <connections>
                         <outlet property="webView" destination="9Ps-Fr-Qfz" id="KRw-m9-nNF"/>
                         <outlet property="webViewHeightConstraint" destination="AHG-uU-f0d" id="X6I-YC-wFT"/>

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
@@ -74,7 +74,7 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
 extension RepositoryDetailReadmeViewController: RepositoryDetailReadmeView {
 
     func evaluateJavaScriptToWebView(javaScript: String) {
-        webView.evaluateJavaScript(javaScript) { [weak self] _, error in
+        webView.evaluateJavaScript(javaScript) { _, error in
             if let error = error {
                 Logger.error(error)
                 return

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
@@ -31,8 +31,12 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // ScrollViewのcontentの高さをobserveし、WebViewの高さとcontentの高さを常に一致させる
         webViewContntObservation = webView.scrollView.observe(\.contentSize) { [weak self] scrollView, _ in
-            self?.webViewHeightConstraint.constant = scrollView.contentSize.height
+            guard let self = self else { return }
+            if self.webViewHeightConstraint.constant != scrollView.contentSize.height {
+                self.webViewHeightConstraint.constant = scrollView.contentSize.height
+            }
         }
 
         presenter.viewDidLoad()
@@ -68,10 +72,20 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
 // MARK: - GitHubRepositoryDetailReadmeView
 
 extension RepositoryDetailReadmeViewController: RepositoryDetailReadmeView {
+
+    func showWebViewLoading() {
+        webView.showLoading(disableUserIteraction: false)
+    }
+
+    func hideWebViewLoading() {
+        webView.hideLoading()
+    }
+
     func evaluateJavaScriptToWebView(javaScript: String) {
-        webView.evaluateJavaScript(javaScript) { _, error in
+        webView.evaluateJavaScript(javaScript) { [weak self] _, error in
             if let error = error {
                 Logger.error(error)
+                self?.presenter.webViewDidFailEvaluateJavaScript(with: error)
                 return
             }
         }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
@@ -73,19 +73,10 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
 
 extension RepositoryDetailReadmeViewController: RepositoryDetailReadmeView {
 
-    func showWebViewLoading() {
-        webView.showLoading(disableUserIteraction: false)
-    }
-
-    func hideWebViewLoading() {
-        webView.hideLoading()
-    }
-
     func evaluateJavaScriptToWebView(javaScript: String) {
         webView.evaluateJavaScript(javaScript) { [weak self] _, error in
             if let error = error {
                 Logger.error(error)
-                self?.presenter.webViewDidFailEvaluateJavaScript(with: error)
                 return
             }
         }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -63,7 +63,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
 
     func searchBarSearchButtonDidTap(searchText: String) {
         DispatchQueue.main.async { [weak self] in
-            self?.view?.startTableViewLoading()
+            self?.view?.showTableViewLoading()
         }
 
         searchTask = Task {
@@ -72,13 +72,13 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                 showEmptyView = self.gitHubRepositories.isEmpty
 
                 DispatchQueue.main.async { [weak self] in
-                    self?.view?.stopTableViewLoading()
+                    self?.view?.hideTableViewLoading()
                     self?.view?.tableViewReloadData()
                     self?.view?.tableViewScrollToTop(animated: false)
                 }
             } catch {
                 DispatchQueue.main.async { [weak self] in
-                    self?.view?.stopTableViewLoading()
+                    self?.view?.hideTableViewLoading()
                 }
                 Logger.error(error)
             }
@@ -93,7 +93,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     func searchBarSearchTextDidChange() {
         searchTask?.cancel()
         DispatchQueue.main.async { [weak self] in
-            self?.view?.stopTableViewLoading()
+            self?.view?.hideTableViewLoading()
         }
     }
 
@@ -110,7 +110,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
             }
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.view?.startTableViewLoading()
+                self?.view?.showTableViewLoading()
             }
 
             searchTask = Task {
@@ -121,13 +121,13 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                     showEmptyView = gitHubRepositories.isEmpty
 
                     DispatchQueue.main.async { [weak self] in
-                        self?.view?.stopTableViewLoading()
+                        self?.view?.hideTableViewLoading()
                         self?.view?.tableViewReloadData()
                         self?.view?.tableViewScrollToTop(animated: false)
                     }
                 } catch {
                     DispatchQueue.main.async { [weak self] in
-                        self?.view?.stopTableViewLoading()
+                        self?.view?.hideTableViewLoading()
                     }
                     Logger.error(error)
                 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -62,16 +62,24 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     }
 
     func searchBarSearchButtonDidTap(searchText: String) {
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.startTableViewLoading()
+        }
+
         searchTask = Task {
             do {
                 self.gitHubRepositories = try await gitHubRepositorySearchUsecase.searchGitHubRepositories(by: searchText)
                 showEmptyView = self.gitHubRepositories.isEmpty
 
                 DispatchQueue.main.async { [weak self] in
+                    self?.view?.stopTableViewLoading()
                     self?.view?.tableViewReloadData()
                     self?.view?.tableViewScrollToTop(animated: false)
                 }
             } catch {
+                DispatchQueue.main.async { [weak self] in
+                    self?.view?.stopTableViewLoading()
+                }
                 Logger.error(error)
             }
         }
@@ -84,6 +92,9 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
 
     func searchBarSearchTextDidChange() {
         searchTask?.cancel()
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.stopTableViewLoading()
+        }
     }
 
     // MARK: - Private
@@ -98,6 +109,10 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                 self?.view?.tableViewScrollToTop(animated: false)
             }
         } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.view?.startTableViewLoading()
+            }
+
             searchTask = Task {
                 do {
                     let initialGitHubRepositories = try await gitHubRepositorySearchUsecase.getTrendingGitHubRepositories()
@@ -106,10 +121,14 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                     showEmptyView = gitHubRepositories.isEmpty
 
                     DispatchQueue.main.async { [weak self] in
+                        self?.view?.stopTableViewLoading()
                         self?.view?.tableViewReloadData()
                         self?.view?.tableViewScrollToTop(animated: false)
                     }
                 } catch {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.view?.stopTableViewLoading()
+                    }
                     Logger.error(error)
                 }
             }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -8,6 +8,12 @@
 
 protocol RepositorySearchView: AnyObject {
 
+    /// TablewViewのロードを開始する
+    func startTableViewLoading()
+
+    /// TableViewのロードを停止する
+    func stopTableViewLoading()
+
     /// TableViewを最上部までスクロールする
     func tableViewScrollToTop(animated: Bool)
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -8,11 +8,11 @@
 
 protocol RepositorySearchView: AnyObject {
 
-    /// TablewViewのロードを開始する
-    func startTableViewLoading()
+    /// TablewViewのロード表示をする
+    func showTableViewLoading()
 
-    /// TableViewのロードを停止する
-    func stopTableViewLoading()
+    /// TableViewのロード表示を隠す
+    func hideTableViewLoading()
 
     /// TableViewを最上部までスクロールする
     func tableViewScrollToTop(animated: Bool)

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -90,6 +90,14 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
 extension RepositorySearchViewController: RepositorySearchView {
 
+    func startTableViewLoading() {
+        tableView.startLoading()
+    }
+
+    func stopTableViewLoading() {
+        tableView.stopLoading()
+    }
+
     func tableViewScrollToTop(animated: Bool) {
         if tableView.numberOfRows(inSection: 0) != 0 {
             tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: animated)

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -90,12 +90,12 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
 
 extension RepositorySearchViewController: RepositorySearchView {
 
-    func startTableViewLoading() {
-        tableView.startLoading()
+    func showTableViewLoading() {
+        tableView.showLoading()
     }
 
-    func stopTableViewLoading() {
-        tableView.stopLoading()
+    func hideTableViewLoading() {
+        tableView.hideLoading()
     }
 
     func tableViewScrollToTop(animated: Bool) {


### PR DESCRIPTION
## 概要
- 検索画面TableViewと詳細画面マークダウン部分にロード表示(クルクル)を追加する

## 実装
### 検索画面
- `UIView+LoadingIndicator`: `UIView.showLoading, hideLoading`といったように容易に`UIActivityIndicator`を表示できるExtension
- `showLoading`内部で`isUserInteractionEnabled`をfalseにし、ロード中に意図しない動作を防ぐ
- viewに`showTableViewLoading`, `hideTableViewLoading`を追加
- リポジトリロード開始で`view.showTableViewLoading`、終了後の描画で`tableView.hideTableViewLoading`

![Oct-27-2021 11-14-18](https://user-images.githubusercontent.com/44288050/138989086-ca1dcd58-c5c9-42c0-af06-a8eb7eb023d2.gif)

### 詳細画面マークダウン
- こちらも`UIView.showLoading`を利用しようとしたが
`WebView`のMarkdown読み込み完了時に呼ばれる適切なイベントがなかったため
上手くshow, hideの制御ができなかった。
- `WebView`で読みこむhtmlにcssで`UIActivityIndicator`のようなクルクルを描画して対処する
    - 利用したライブラリ: https://github.com/swordray/ispinner

![Oct-27-2021 11-14-34](https://user-images.githubusercontent.com/44288050/138989238-21619db0-2650-4c60-8d89-0ec535ff6614.gif)
