### PR TITLE
エラーメッセージ・エラーViewを実装する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		E27171632728F7E800E3C1ED /* SwiftEntryKit in Frameworks */ = {isa = PBXBuildFile; productRef = E27171622728F7E800E3C1ED /* SwiftEntryKit */; };
 		E27171652728F84000E3C1ED /* MessageBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27171642728F84000E3C1ED /* MessageBanner.swift */; };
 		E27171672728F8B600E3C1ED /* BannerShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27171662728F8B600E3C1ED /* BannerShowable.swift */; };
+		E271716A2728F99200E3C1ED /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27171692728F99200E3C1ED /* ErrorViewController.swift */; };
+		E271716C2728F9EC00E3C1ED /* ErrorViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E271716B2728F9EC00E3C1ED /* ErrorViewController.storyboard */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -160,6 +162,8 @@
 		E271715F2728E93600E3C1ED /* ispinner.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = ispinner.css; sourceTree = "<group>"; };
 		E27171642728F84000E3C1ED /* MessageBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBanner.swift; sourceTree = "<group>"; };
 		E27171662728F8B600E3C1ED /* BannerShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowable.swift; sourceTree = "<group>"; };
+		E27171692728F99200E3C1ED /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
+		E271716B2728F9EC00E3C1ED /* ErrorViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ErrorViewController.storyboard; sourceTree = "<group>"; };
 		E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -494,6 +498,15 @@
 			path = Empty;
 			sourceTree = "<group>";
 		};
+		E27171682728F98300E3C1ED /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				E27171692728F99200E3C1ED /* ErrorViewController.swift */,
+				E271716B2728F9EC00E3C1ED /* ErrorViewController.storyboard */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		E28669412725A5DC00833B6B /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -506,6 +519,7 @@
 		E286694A2725F62600833B6B /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				E27171682728F98300E3C1ED /* Error */,
 				E27087DB2728482100AE7223 /* Empty */,
 				E286694B2725F63E00833B6B /* VStackViewController.swift */,
 				E27171642728F84000E3C1ED /* MessageBanner.swift */,
@@ -660,6 +674,7 @@
 				E25070582724491600013FF1 /* RootViewController.storyboard in Resources */,
 				E250705F27244BED00013FF1 /* SplashViewController.storyboard in Resources */,
 				E28669582725FEE400833B6B /* RepositoryDetailCountViewController.storyboard in Resources */,
+				E271716C2728F9EC00E3C1ED /* ErrorViewController.storyboard in Resources */,
 				E27087BD2726894E00AE7223 /* RepositoryDetailReadmeViewController.storyboard in Resources */,
 				E27087CA27276B4600AE7223 /* mdbase.html in Resources */,
 				E27171602728E93600E3C1ED /* ispinner.css in Resources */,
@@ -732,6 +747,7 @@
 				E27087CE2727A09100AE7223 /* RepositoryDetailReadMePresenter.swift in Sources */,
 				E250707D27247BD200013FF1 /* GitHubRepositorySearchUsecase.swift in Sources */,
 				E25070522724476C00013FF1 /* Storyboardable.swift in Sources */,
+				E271716A2728F99200E3C1ED /* ErrorViewController.swift in Sources */,
 				E2507092272494BA00013FF1 /* SplashProtocol.swift in Sources */,
 				E250706B27246FB100013FF1 /* AppError.swift in Sources */,
 				E250706D2724712100013FF1 /* APITargetType.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		E271715E2728C05D00E3C1ED /* UIView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */; };
 		E27171602728E93600E3C1ED /* ispinner.css in Resources */ = {isa = PBXBuildFile; fileRef = E271715F2728E93600E3C1ED /* ispinner.css */; };
 		E27171632728F7E800E3C1ED /* SwiftEntryKit in Frameworks */ = {isa = PBXBuildFile; productRef = E27171622728F7E800E3C1ED /* SwiftEntryKit */; };
+		E27171652728F84000E3C1ED /* MessageBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27171642728F84000E3C1ED /* MessageBanner.swift */; };
+		E27171672728F8B600E3C1ED /* BannerShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27171662728F8B600E3C1ED /* BannerShowable.swift */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -156,6 +158,8 @@
 		E27087DC2728483600AE7223 /* EmptyViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EmptyViewController.storyboard; sourceTree = "<group>"; };
 		E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+LoadingIndicator.swift"; sourceTree = "<group>"; };
 		E271715F2728E93600E3C1ED /* ispinner.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = ispinner.css; sourceTree = "<group>"; };
+		E27171642728F84000E3C1ED /* MessageBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBanner.swift; sourceTree = "<group>"; };
+		E27171662728F8B600E3C1ED /* BannerShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowable.swift; sourceTree = "<group>"; };
 		E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailProtocol.swift; sourceTree = "<group>"; };
 		E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailPresenter.swift; sourceTree = "<group>"; };
 		E286693F2724D80F00833B6B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -263,6 +267,7 @@
 				E25070512724476C00013FF1 /* Storyboardable.swift */,
 				E28669462725AE3200833B6B /* NibInstantiatable.swift */,
 				E27087D52727E7E000AE7223 /* WebViewShowable.swift */,
+				E27171662728F8B600E3C1ED /* BannerShowable.swift */,
 				E250708F272492B200013FF1 /* Presentation.swift */,
 				E286694A2725F62600833B6B /* Common */,
 				E25070492724467500013FF1 /* Screen */,
@@ -503,6 +508,7 @@
 			children = (
 				E27087DB2728482100AE7223 /* Empty */,
 				E286694B2725F63E00833B6B /* VStackViewController.swift */,
+				E27171642728F84000E3C1ED /* MessageBanner.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -693,6 +699,7 @@
 				E28669442725A64900833B6B /* RepositoryTableViewCell.swift in Sources */,
 				E250709827249DE700013FF1 /* RepositorySearchPresenter.swift in Sources */,
 				E28669472725AE3200833B6B /* NibInstantiatable.swift in Sources */,
+				E27171672728F8B600E3C1ED /* BannerShowable.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailHeadingViewController.swift in Sources */,
 				E250708227247E8800013FF1 /* LoggerPlugin.swift in Sources */,
 				E25070772724775F00013FF1 /* User.swift in Sources */,
@@ -734,6 +741,7 @@
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				E250709627249C1500013FF1 /* RepositorySearchProtocol.swift in Sources */,
 				E250705A2724497E00013FF1 /* MainViewController.swift in Sources */,
+				E27171652728F84000E3C1ED /* MessageBanner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		E27087DD2728483600AE7223 /* EmptyViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E27087DC2728483600AE7223 /* EmptyViewController.storyboard */; };
 		E271715E2728C05D00E3C1ED /* UIView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E271715D2728C05D00E3C1ED /* UIView+LoadingIndicator.swift */; };
 		E27171602728E93600E3C1ED /* ispinner.css in Resources */ = {isa = PBXBuildFile; fileRef = E271715F2728E93600E3C1ED /* ispinner.css */; };
+		E27171632728F7E800E3C1ED /* SwiftEntryKit in Frameworks */ = {isa = PBXBuildFile; productRef = E27171622728F7E800E3C1ED /* SwiftEntryKit */; };
 		E28669352724D52E00833B6B /* RepositoryDetailProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669342724D52E00833B6B /* RepositoryDetailProtocol.swift */; };
 		E28669372724D5E700833B6B /* RepositoryDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28669362724D5E700833B6B /* RepositoryDetailPresenter.swift */; };
 		E286693D2724D7DF00833B6B /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = E286693C2724D7DF00833B6B /* Nuke */; };
@@ -177,6 +178,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E27171632728F7E800E3C1ED /* SwiftEntryKit in Frameworks */,
 				E286693D2724D7DF00833B6B /* Nuke in Frameworks */,
 				E250706727246E9700013FF1 /* Moya in Frameworks */,
 				E250708E272488E000013FF1 /* SwiftyBeaver in Frameworks */,
@@ -547,6 +549,7 @@
 				E250706627246E9700013FF1 /* Moya */,
 				E250708D272488E000013FF1 /* SwiftyBeaver */,
 				E286693C2724D7DF00833B6B /* Nuke */,
+				E27171622728F7E800E3C1ED /* SwiftEntryKit */,
 			);
 			productName = iOSEngineerCodeCheck;
 			productReference = BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */;
@@ -624,6 +627,7 @@
 				E250706527246E9600013FF1 /* XCRemoteSwiftPackageReference "Moya" */,
 				E25070892724883200013FF1 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
 				E286693B2724D7DF00833B6B /* XCRemoteSwiftPackageReference "Nuke" */,
+				E27171612728F7E800E3C1ED /* XCRemoteSwiftPackageReference "SwiftEntryKit" */,
 			);
 			productRefGroup = BFD945DC244DC5E80012785A /* Products */;
 			projectDirPath = "";
@@ -1078,6 +1082,14 @@
 				minimumVersion = 1.9.5;
 			};
 		};
+		E27171612728F7E800E3C1ED /* XCRemoteSwiftPackageReference "SwiftEntryKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huri000/SwiftEntryKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		E286693B2724D7DF00833B6B /* XCRemoteSwiftPackageReference "Nuke" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/Nuke.git";
@@ -1098,6 +1110,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E25070892724883200013FF1 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */;
 			productName = SwiftyBeaver;
+		};
+		E27171622728F7E800E3C1ED /* SwiftEntryKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E27171612728F7E800E3C1ED /* XCRemoteSwiftPackageReference "SwiftEntryKit" */;
+			productName = SwiftEntryKit;
 		};
 		E286693C2724D7DF00833B6B /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/Contents.json
+++ b/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/error.colorset/Contents.json
+++ b/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/error.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.314",
+          "red" : "0.886"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/warn.colorset/Contents.json
+++ b/iOSEngineerCodeCheck/Resource/Assets.xcassets/Banner/warn.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.216",
+          "green" : "0.616",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSEngineerCodeCheck/UI/BannerShowable.swift
+++ b/iOSEngineerCodeCheck/UI/BannerShowable.swift
@@ -1,0 +1,23 @@
+//
+//  BannerShowable.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/27.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+protocol BannerShowable {
+    func showErrorBanner(_ title: String, with message: String?)
+    func showWarnBanner(_ title: String, with message: String?)
+}
+
+extension BannerShowable {
+    
+    func showErrorBanner(_ title: String, with message: String? = nil) {
+        MessageBanner.shared.error(title, with: message)
+    }
+
+    func showWarnBanner(_ title: String, with message: String? = nil) {
+        MessageBanner.shared.warn(title, with: message)
+    }
+}

--- a/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.storyboard
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Error View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="ErrorViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="4Jz-OG-ZX7">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="229"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="vJW-KI-uSX">
+                                <rect key="frame" x="161" y="72" width="92" height="85.5"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vgu-I7-IFD">
+                                        <rect key="frame" x="16" y="0.0" width="60" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="60" id="0Go-e3-687"/>
+                                            <constraint firstAttribute="height" constant="60" id="coU-E4-3RB"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <state key="normal">
+                                            <imageReference key="image" image="arrow.clockwise" catalog="system" symbolScale="large"/>
+                                            <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="38"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="refreshButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="VaV-lP-Pgi"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="再読み込み" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FLS-dV-eRq">
+                                        <rect key="frame" x="0.0" y="64" width="92" height="21.5"/>
+                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="WX1-Gz-E0Z"/>
+                        <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vJW-KI-uSX" firstAttribute="centerX" secondItem="4Jz-OG-ZX7" secondAttribute="centerX" id="Qza-VM-VO6"/>
+                            <constraint firstItem="vJW-KI-uSX" firstAttribute="centerY" secondItem="4Jz-OG-ZX7" secondAttribute="centerY" id="Rf9-da-HB3"/>
+                        </constraints>
+                    </view>
+                    <size key="freeformSize" width="414" height="229"/>
+                    <connections>
+                        <outlet property="refreshButton" destination="vgu-I7-IFD" id="S1X-Wo-OHf"/>
+                        <outlet property="refreshLabel" destination="FLS-dV-eRq" id="83g-S6-TOc"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-4.3478260869565224" y="-114.84375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="arrow.clockwise" catalog="system" width="115" height="128"/>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.storyboard
@@ -22,6 +22,7 @@
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vgu-I7-IFD">
                                         <rect key="frame" x="16" y="0.0" width="60" height="60"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="60" id="0Go-e3-687"/>
                                             <constraint firstAttribute="height" constant="60" id="coU-E4-3RB"/>
@@ -45,7 +46,7 @@
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="WX1-Gz-E0Z"/>
-                        <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vJW-KI-uSX" firstAttribute="centerX" secondItem="4Jz-OG-ZX7" secondAttribute="centerX" id="Qza-VM-VO6"/>
                             <constraint firstItem="vJW-KI-uSX" firstAttribute="centerY" secondItem="4Jz-OG-ZX7" secondAttribute="centerY" id="Rf9-da-HB3"/>
@@ -64,7 +65,7 @@
     </scenes>
     <resources>
         <image name="arrow.clockwise" catalog="system" width="115" height="128"/>
-        <systemColor name="secondarySystemGroupedBackgroundColor">
+        <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>

--- a/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Common/Error/ErrorViewController.swift
@@ -1,0 +1,58 @@
+//
+//  ErrorViewController.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/27.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+final class ErrorViewController: UIViewController, Storyboardable {
+
+    // MARK: - Outlet
+
+    @IBOutlet private weak var refreshButton: UIButton!
+    @IBOutlet private weak var refreshLabel: UILabel! {
+        didSet {
+            refreshLabel.text = refreshTitle
+        }
+    }
+
+    // MARK: - Property
+
+    private var refreshTitle: String!
+    private var hideRefreshButton: Bool!
+
+    private var refreshButtonHandler: (() -> Void)?
+
+    // MARK: - Static
+
+    static func build(refreshTitle: String, hideRefreshButton: Bool) -> Self {
+        let viewController = initViewController()
+        viewController.refreshTitle = refreshTitle
+        viewController.hideRefreshButton = hideRefreshButton
+
+        return viewController
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        refreshButton.isHidden = hideRefreshButton
+    }
+
+    // MARK: - Public
+
+    func setRefreshButtonHandler(handler: @escaping () -> Void) {
+        self.refreshButtonHandler = handler
+    }
+
+    // MARK: - Action
+
+    @IBAction private func refreshButtonDidTap(_ sender: Any) {
+        refreshButtonHandler?()
+    }
+}
+

--- a/iOSEngineerCodeCheck/UI/Common/MessageBanner.swift
+++ b/iOSEngineerCodeCheck/UI/Common/MessageBanner.swift
@@ -1,0 +1,68 @@
+//
+//  MessageBanner.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by kntk on 2021/10/27.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+
+import SwiftEntryKit
+import UIKit
+
+final class MessageBanner {
+
+    // MARK: - Static
+
+    static let shared = MessageBanner()
+
+    // MARK: - Public
+
+    func error(_ title: String, with message: String? = nil) {
+        let attribute = createBannerAttribute(name: "Error", color: UIColor(named: "error")!, feedBack: .error, duration: 5.0)
+
+        var title = title
+        if let message = message {
+            title = "\(title)\n\(message)"
+        }
+
+        let label = EKProperty.LabelContent(text: title, style: .init(font: UIFont.systemFont(ofSize: 15), color: .white, alignment: .center))
+        let note = EKNoteMessageView(with: label)
+
+        SwiftEntryKit.display(entry: note, using: attribute)
+    }
+
+    func warn(_ title: String, with message: String? = nil) {
+        let attribute = createBannerAttribute(name: "Warn", color: UIColor(named: "warn")!, feedBack: .warning, duration: 5.0)
+
+        var title = title
+        if let message = message {
+            title = "\(title)\n\(message)"
+        }
+
+        let label = EKProperty.LabelContent(text: title, style: .init(font: UIFont.systemFont(ofSize: 15), color: .white, alignment: .center))
+        let note = EKNoteMessageView(with: label)
+
+        SwiftEntryKit.display(entry: note, using: attribute)
+    }
+
+    // MARK: - Private
+
+    private func createBannerAttribute(name: String, color: UIColor, feedBack: EKAttributes.NotificationHapticFeedback, duration: Double) -> EKAttributes {
+        var attribute = EKAttributes.topToast
+        attribute.displayMode = .inferred
+        attribute.name = name
+        attribute.displayDuration = duration
+        attribute.hapticFeedbackType = feedBack
+        attribute.popBehavior = .animated(animation: .translation)
+        attribute.entryBackground = .color(color: EKColor.init(color))
+        attribute.statusBar = .light
+
+        return attribute
+    }
+
+    // MARK: - Initializer
+
+    private init() {}
+}
+

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMePresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMePresenter.swift
@@ -70,6 +70,11 @@ final  class RepositoryDetailReadMePresenter: RepositoryDetailReadmePresentation
         }
     }
 
+    func webViewDidFailEvaluateJavaScript(with error: Error) {
+        Logger.error(error)
+        handle(error)
+    }
+
     func webViewCanNavigate(to url: URL) -> Bool {
         // 初期読み込みは許可
         if url == readmeBaseHtmlURL {
@@ -117,10 +122,45 @@ final  class RepositoryDetailReadMePresenter: RepositoryDetailReadmePresentation
                     }
                 } else {
                     Logger.error(apierror)
+                    handle(apierror)
                 }
             } catch {
                 Logger.error(error)
+                handle(error)
             }
+        }
+    }
+
+    private func handle(_ error: Error) {
+
+        let title: String
+        let message: String
+
+        if let apiErorr = error as? APIError {
+            switch apiErorr {
+            case .statusCode(let statusCodeError):
+                title = "システムエラー"
+                message = "再度お試しください。\n\(statusCodeError._domain), \(statusCodeError._code)"
+
+            case .response(let error):
+                title = "ネットワークエラー"
+                message = "通信状況をお確かめの上、再度お試しください。\n\(error._domain), \(error._code)"
+
+            case .decode(let error):
+                title = "パースエラー"
+                message = "再度お試しください。\n\(error._domain), \(error._code)"
+
+            case .base64Decode:
+                title = "パースエラー"
+                message = "再度お試しください。\n\(error._domain), \(error._code)"
+            }
+        } else {
+            title = "システムエラー"
+            message = "再度お試しください。\n\(error._domain), \(error._code)"
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.showErrorBanner(title, with: message)
         }
     }
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
@@ -23,6 +23,12 @@ protocol RepositoryDetailReadmeView: AnyObject, WebViewShowable, BannerShowable 
 
     /// readmeViewControllerを隠す
     func hideReadmeViewController()
+
+    /// ErrorViewを表示する
+    func showErrorView()
+
+    /// ErrorViewを非表示にする
+    func hideErrorView()
 }
 
 protocol RepositoryDetailReadmePresentation: Presentation {
@@ -39,5 +45,8 @@ protocol RepositoryDetailReadmePresentation: Presentation {
     ///     - url: 読み込みURL
     /// - returns: 読み込みをして良いかどうか
     func webViewCanNavigate(to url: URL) -> Bool
+
+    /// ErroViewのリフレッシュボタンが押された
+    func errorViewRefreshButtonDidTap()
 }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol RepositoryDetailReadmeView: AnyObject, WebViewShowable {
+protocol RepositoryDetailReadmeView: AnyObject, WebViewShowable, BannerShowable {
 
     /// WebViewをセットアップする
     /// - parameters:
@@ -29,6 +29,9 @@ protocol RepositoryDetailReadmePresentation: Presentation {
 
     /// WebViewのセットアップが終了した
     func webViewDidFinishSetup()
+
+    /// WebViewがJavaScriptの実行に失敗した
+    func webViewDidFailEvaluateJavaScript(with error: Error)
 
     /// WebViewがURLの読み込みをして良いかどうか
     ///

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
@@ -74,14 +74,13 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
 extension RepositoryDetailReadmeViewController: RepositoryDetailReadmeView {
 
     func evaluateJavaScriptToWebView(javaScript: String) {
-        webView.evaluateJavaScript(javaScript) { _, error in
+        webView.evaluateJavaScript(javaScript) { [weak self] _, error in
             if let error = error {
-                Logger.error(error)
+                self?.presenter.webViewDidFailEvaluateJavaScript(with: error)
                 return
             }
         }
     }
-
 
     func hideReadmeViewController() {
         view.isHidden = true

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadmeViewController.swift
@@ -26,10 +26,26 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
 
     private var webViewContntObservation: NSKeyValueObservation?
 
+    // MARK: - Property
+
+    var presenter: RepositoryDetailReadmePresentation!
+
+    private lazy var errorViewController = ErrorViewController.build(refreshTitle: "再読み込み", hideRefreshButton: false)
+
+    // MARK: - Build
+
+    static func build() -> Self {
+        return initViewController()
+    }
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        errorViewController.setRefreshButtonHandler { [weak self] in
+            self?.presenter.errorViewRefreshButtonDidTap()
+        }
 
         // ScrollViewのcontentの高さをobserveし、WebViewの高さとcontentの高さを常に一致させる
         webViewContntObservation = webView.scrollView.observe(\.contentSize) { [weak self] scrollView, _ in
@@ -57,16 +73,6 @@ final class RepositoryDetailReadmeViewController: UIViewController, Storyboardab
     deinit {
         presenter.viewDidStop()
     }
-
-    // MARK: - Property
-
-    var presenter: RepositoryDetailReadmePresentation!
-
-    // MARK: - Build
-
-    static func build() -> Self {
-        return initViewController()
-    }
 }
 
 // MARK: - GitHubRepositoryDetailReadmeView
@@ -88,6 +94,14 @@ extension RepositoryDetailReadmeViewController: RepositoryDetailReadmeView {
 
     func setupWebView(url: URL) {
         webView.load(URLRequest(url: url))
+    }
+
+    func showErrorView() {
+        webView.addSubview(errorViewController.view, constraints: .allEdges())
+    }
+
+    func hideErrorView() {
+        errorViewController.view.removeFromSuperview()
     }
 }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -108,6 +108,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                     self?.view?.tableViewScrollToTop(animated: false)
                 }
             } catch {
+                self.gitHubRepositories = []
                 showErrorView = true
 
                 DispatchQueue.main.async { [weak self] in

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -26,6 +26,8 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     // 非検索状態で表示される「おすすめ」的な立ち位置のリポジトリ一覧
     private var initialGitHubRepositories: [GitHubRepository]?
 
+    private var searchText = ""
+
     private var searchTask: Task<Void, Error>?
 
     // MARK: - Initializer
@@ -61,7 +63,7 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
         }
     }
 
-    func searchBarSearchButtonDidTap(searchText: String) {
+    func searchBarSearchButtonDidTap() {
         DispatchQueue.main.async { [weak self] in
             self?.view?.showTableViewLoading()
         }
@@ -92,7 +94,8 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
         setInitialGitHubRepositories()
     }
 
-    func searchBarSearchTextDidChange() {
+    func searchBarSearchTextDidChange(searchText: String) {
+        self.searchText = searchText
         searchTask?.cancel()
         DispatchQueue.main.async { [weak self] in
             self?.view?.hideTableViewLoading()

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -65,6 +65,33 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
     }
 
     func searchBarSearchButtonDidTap() {
+        searchGitHubRepositories()
+    }
+
+    func searchBarCancelButtonDidTap() {
+        searchTask?.cancel()
+        setInitialGitHubRepositories()
+    }
+
+    func searchBarSearchTextDidChange(searchText: String) {
+        self.searchText = searchText
+        searchTask?.cancel()
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.hideTableViewLoading()
+        }
+    }
+
+    func errorViewRefreshButtonDidTap() {
+        if initialGitHubRepositories == nil {
+            setInitialGitHubRepositories()
+        } else {
+            searchGitHubRepositories()
+        }
+    }
+
+    // MARK: - Private
+
+    private func searchGitHubRepositories() {
         DispatchQueue.main.async { [weak self] in
             self?.view?.showTableViewLoading()
         }
@@ -93,29 +120,6 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
             }
         }
     }
-
-    func searchBarCancelButtonDidTap() {
-        searchTask?.cancel()
-        setInitialGitHubRepositories()
-    }
-
-    func searchBarSearchTextDidChange(searchText: String) {
-        self.searchText = searchText
-        searchTask?.cancel()
-        DispatchQueue.main.async { [weak self] in
-            self?.view?.hideTableViewLoading()
-        }
-    }
-
-    func errorViewRefreshButtonDidTap() {
-        if initialGitHubRepositories == nil {
-            setInitialGitHubRepositories()
-        } else {
-            searchBarSearchButtonDidTap()
-        }
-    }
-
-    // MARK: - Private
 
     private func setInitialGitHubRepositories() {
         // 既に取得してある場合は使い回す

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -80,7 +80,9 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                 DispatchQueue.main.async { [weak self] in
                     self?.view?.hideTableViewLoading()
                 }
+                
                 Logger.error(error)
+                handle(error)
             }
         }
     }
@@ -129,9 +131,44 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
                     DispatchQueue.main.async { [weak self] in
                         self?.view?.hideTableViewLoading()
                     }
+
                     Logger.error(error)
+                    handle(error)
                 }
             }
+        }
+    }
+
+    private func handle(_ error: Error) {
+
+        let title: String
+        let message: String
+
+        if let apiErorr = error as? APIError {
+            switch apiErorr {
+            case .statusCode(let statusCodeError):
+                title = "システムエラー"
+                message = "再度お試しください。\n\(statusCodeError._domain), \(statusCodeError._code)"
+
+            case .response(let error):
+                title = "ネットワークエラー"
+                message = "通信状況をお確かめの上、再度お試しください。\n\(error._domain), \(error._code)"
+
+            case .decode(let error):
+                title = "パースエラー"
+                message = "再度お試しください。\n\(error._domain), \(error._code)"
+
+            case .base64Decode:
+                title = "パースエラー"
+                message = "再度お試しください。\n\(error._domain), \(error._code)"
+            }
+        } else {
+            title = "システムエラー"
+            message = "再度お試しください。\n\(error._domain), \(error._code)"
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.view?.showErrorBanner(title, with: message)
         }
     }
 }

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -52,12 +52,15 @@ protocol RepositorySearchPresentation: Presentation {
     ///
     /// - parameters:
     ///     - searchText: 検索語
-    func searchBarSearchButtonDidTap(searchText: String)
+    func searchBarSearchButtonDidTap()
 
     /// キャンセルボタンが押された
     func searchBarCancelButtonDidTap()
 
     /// 検索文字が変更された
-    func searchBarSearchTextDidChange()
+    func searchBarSearchTextDidChange(searchText: String)
+
+    /// ErroViewのリフレッシュボタンが押された
+    func errorViewRefreshButtonDidTap()
 }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -29,6 +29,9 @@ protocol RepositorySearchView: AnyObject, BannerShowable {
 
 protocol RepositorySearchPresentation: Presentation {
 
+    /// ErrorViewを表示するかどうか
+    var showErrorView: Bool { get }
+
     /// EmptyViewを表示するかどうか
     var showEmptyView: Bool { get }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 YUMEMI Inc. All rights reserved.
 //
 
-protocol RepositorySearchView: AnyObject {
+protocol RepositorySearchView: AnyObject, BannerShowable {
 
     /// TablewViewのロード表示をする
     func showTableViewLoading()

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -130,11 +130,11 @@ extension RepositorySearchViewController: RepositorySearchView {
 extension RepositorySearchViewController: UISearchBarDelegate {
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        presenter.searchBarSearchTextDidChange()
+        presenter.searchBarSearchTextDidChange(searchText: searchText)
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        presenter.searchBarSearchButtonDidTap(searchText: searchBar.text ?? "")
+        presenter.searchBarSearchButtonDidTap()
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchViewController.swift
@@ -23,6 +23,7 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
     }()
 
     private lazy var emptyViewController = EmptyViewController.build(emptyTitle: "リポジトリがありません")
+    private lazy var errorViewController = ErrorViewController.build(refreshTitle: "再読み込み", hideRefreshButton: false)
 
     // MARK: - Build
 
@@ -36,9 +37,14 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
         super.viewDidLoad()
 
         tableView.register(RepositoryTableViewCell.self)
+
         title = "検索"
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
+
+        errorViewController.setRefreshButtonHandler { [weak self] in
+            self?.presenter.errorViewRefreshButtonDidTap()
+        }
         
         presenter.viewDidLoad()
     }
@@ -74,7 +80,13 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return presenter.showEmptyView ? emptyViewController.view : nil
+        if presenter.showErrorView {
+            return errorViewController.view
+        } else if presenter.showEmptyView {
+            return emptyViewController.view
+        } else {
+            return nil
+        }
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -82,7 +94,7 @@ final class RepositorySearchViewController: UITableViewController, Storyboardabl
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return presenter.showEmptyView ? tableView.bounds.height : CGFloat.leastNormalMagnitude
+        return presenter.showEmptyView || presenter.showErrorView ? tableView.bounds.height : CGFloat.leastNormalMagnitude
     }
 }
 


### PR DESCRIPTION
## 概要
- エラー時にエラーメッセージの表示や再取得を促すErrorViewを実装する

## 実装
### エラーメッセージ
- [SwiftEntryKit](https://github.com/huri000/SwiftEntryKit.git) のバナー形式で表示する
- `SwiftEntryKit`をラップした`MessageBanner`を追加
- `MessageBanner`を利用した、Viewにmixinして利用する`BannerShowable`を追加
- 各Presenterでエラーからメッセージを生成し、`BannerShowable`を利用してメッセージを表示する

### ErrorView
- `ErrorViewController`を追加
- 各`ViewController`で`ErrorViewController`を保持する
- 検索画面
    - 検索API失敗時に表示
    - `EmptyView`と同様に`TableView`のヘッダーを利用して`ErrorView`を表示
    - `Presenter`にエラーを表示するべきかどうかのフラグ`showError`を追加
- 詳細画面・マークダウン
    - Readme取得のAPIもしくは`WebView`描画でエラーが起きた場合に表示

| 検索画面 | 詳細画面 |
| ------ | ------ |
| ![Simulator Screen Shot - iPhone 13 - 2021-10-27 at 13 38 51](https://user-images.githubusercontent.com/44288050/139001913-25076056-d12d-414d-ba17-ebeb34cbe2a0.png) | ![Simulator Screen Shot - iPhone 13 - 2021-10-27 at 13 40 36](https://user-images.githubusercontent.com/44288050/139001934-c446a1c7-9827-427b-8888-801d8e154982.png)  |
