### PR TITLE
コメントが足りない部分を修正

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -501,8 +501,8 @@
 		E27171682728F98300E3C1ED /* Error */ = {
 			isa = PBXGroup;
 			children = (
-				E27171692728F99200E3C1ED /* ErrorViewController.swift */,
 				E271716B2728F9EC00E3C1ED /* ErrorViewController.storyboard */,
+				E27171692728F99200E3C1ED /* ErrorViewController.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";

--- a/iOSEngineerCodeCheck/Repository/GitHubRepositoryReadmeRepository.swift
+++ b/iOSEngineerCodeCheck/Repository/GitHubRepositoryReadmeRepository.swift
@@ -10,6 +10,12 @@ import Foundation
 
 protocol GitHubRepositoryReadmeRepository {
 
+    /// 特定のGitHubのリポジトリのReadmeを取得する
+    ///
+    /// - parameters:
+    ///     - repository: リポジトリ名
+    ///     - owner: 所有者名
+    /// - returns: Readmeの文字列
     func getGitHubRepositoryReadme(repository: String, owner: String) async throws -> String
 }
 

--- a/iOSEngineerCodeCheck/Repository/GitHubRepositoryRepository.swift
+++ b/iOSEngineerCodeCheck/Repository/GitHubRepositoryRepository.swift
@@ -8,6 +8,12 @@
 
 protocol GitHubRepositoryRepository {
 
+    /// 指定された検索語でGitHubのリポジトリを検索する
+    ///
+    /// - parameters:
+    ///     - word: 検索語
+    ///     - sort: 検索結果のソート方法
+    /// - returns: 検索結果
     func searchGitHubRepositories(by word: String, sort: GitHubRepositorySortKind) async throws -> [GitHubRepository]
 }
 

--- a/iOSEngineerCodeCheck/UI/BannerShowable.swift
+++ b/iOSEngineerCodeCheck/UI/BannerShowable.swift
@@ -7,7 +7,21 @@
 //
 
 protocol BannerShowable {
+
+    /// エラーメッセージをバナーで表示する
+    /// バナーの色は赤色
+    ///
+    /// - parameters:
+    ///     - title: タイトル(1行目に表示)
+    ///     - message: メッセージ(2行目に表示)
     func showErrorBanner(_ title: String, with message: String?)
+
+    /// 警告メッセージをバナーで表示する
+    /// バナーの色は黄色
+    ///
+    /// - parameters:
+    ///     - title: タイトル(1行目に表示)
+    ///     - message: メッセージ(2行目に表示)
     func showWarnBanner(_ title: String, with message: String?)
 }
 

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailCount/RepositoryDetailCountViewController.storyboard
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailCount/RepositoryDetailCountViewController.storyboard
@@ -146,7 +146,7 @@
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SBn-Fj-Pl5">
                                                                     <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
                                                                     <subviews>
-                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow.branch" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="t3B-ZJ-pFP">
+                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow.triangle.branch" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="t3B-ZJ-pFP">
                                                                             <rect key="frame" x="4" y="6" width="24" height="21"/>
                                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -268,7 +268,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="arrow.branch" catalog="system" width="128" height="108"/>
+        <image name="arrow.triangle.branch" catalog="system" width="128" height="108"/>
         <image name="exclamationmark.circle" catalog="system" width="128" height="121"/>
         <image name="eye" catalog="system" width="128" height="81"/>
         <image name="star" catalog="system" width="128" height="116"/>

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol RepositoryDetailReadmeView: AnyObject, WebViewShowable, BannerShowable {
 
     /// WebViewをセットアップする
+    /// 
     /// - parameters:
     ///     - url: 初期読み込みのurl
     func setupWebView(url: URL)

--- a/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositoryDetail/RepositoryDetailReadMe/RepositoryDetailReadMeProtocol.swift
@@ -37,6 +37,9 @@ protocol RepositoryDetailReadmePresentation: Presentation {
     func webViewDidFinishSetup()
 
     /// WebViewがJavaScriptの実行に失敗した
+    ///
+    /// - parameters:
+    ///     - error: 原因のエラー
     func webViewDidFailEvaluateJavaScript(with error: Error)
 
     /// WebViewがURLの読み込みをして良いかどうか

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -52,15 +52,15 @@ protocol RepositorySearchPresentation: Presentation {
     func tableViewDidSelectRow(at index: Int)
 
     /// 検索ボタンが押された
-    ///
-    /// - parameters:
-    ///     - searchText: 検索語
     func searchBarSearchButtonDidTap()
 
     /// キャンセルボタンが押された
     func searchBarCancelButtonDidTap()
 
     /// 検索文字が変更された
+    /// 
+    /// - parameters:
+    ///     - searchText: 検索語
     func searchBarSearchTextDidChange(searchText: String)
 
     /// ErroViewのリフレッシュボタンが押された

--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchProtocol.swift
@@ -15,6 +15,9 @@ protocol RepositorySearchView: AnyObject, BannerShowable {
     func hideTableViewLoading()
 
     /// TableViewを最上部までスクロールする
+    ///
+    /// - parameters:
+    ///     - animated: アニメーションをするかどうか
     func tableViewScrollToTop(animated: Bool)
 
     /// TableViewをリロードする

--- a/iOSEngineerCodeCheck/UI/WebViewShowable.swift
+++ b/iOSEngineerCodeCheck/UI/WebViewShowable.swift
@@ -9,8 +9,17 @@
 import SafariServices
 
 protocol WebViewShowable {
+
+    /// SafariアプリでURLを開く
+    ///
+    /// - parameters:
+    ///     - url: 開くURL
     func openSafariApp(url: URL)
 
+    /// SafariViewControllerでURLを開く
+    ///
+    /// - parameters:
+    ///     - url: 開くURL
     func presentSafariViewController(url: URL)
 }
 

--- a/iOSEngineerCodeCheck/Usecase/GitHubRepositoryDetailUsecase.swift
+++ b/iOSEngineerCodeCheck/Usecase/GitHubRepositoryDetailUsecase.swift
@@ -9,6 +9,12 @@
 
 protocol GitHubRepositoryDetailUsecase {
 
+    /// 特定のGitHubのリポジトリのReadmeを取得する
+    ///
+    /// - parameters:
+    ///     - repository: リポジトリ名
+    ///     - owner: 所有者名
+    /// - returns: Readmeの文字列
     func getGitHubRepositoryReadme(repository: String, owner: String) async throws -> String
 }
 

--- a/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
+++ b/iOSEngineerCodeCheck/Usecase/GitHubRepositorySearchUsecase.swift
@@ -8,8 +8,16 @@
 
 protocol GitHubReposiotySearchUsecase {
 
+    /// 指定された検索語でGitHubのリポジトリを検索する
+    ///
+    /// - parameters:
+    ///     - word: 検索語
+    /// - returns: 検索結果
     func searchGitHubRepositories(by word: String) async throws -> [GitHubRepository]
 
+    /// GitHubのリポジトリのトレンドを取得する
+    ///
+    /// - returns: トレンドのGitHubリポジトリ
     func getTrendingGitHubRepositories() async throws -> [GitHubRepository]
 }
 


### PR DESCRIPTION
## 概要
- `Usecase`, `Repository`, `Presentation`等のprotocolで説明がないメソッドにコメントを追加
- `RepositoryDetailCount`のForkのアイコンに使っていた`arrow.branch`がdeprecatedだったので`arrow.triangle.branch`に