### PR TITLE
検索で422が帰ってきた場合にバリデーションエラーであることを表示する

### DIFF
--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/RepositorySearchPresenter.swift
@@ -175,8 +175,13 @@ final class RepositorySearchPresenter: RepositorySearchPresentation {
         if let apiErorr = error as? APIError {
             switch apiErorr {
             case .statusCode(let statusCodeError):
-                title = "システムエラー"
-                message = "再度お試しください。\n\(statusCodeError._domain), \(statusCodeError._code)"
+                if case .validationFailed = statusCodeError {
+                    title = "バリデーションエラー"
+                    message = "入力に利用できない文字が含まれています。\n入力を変更して再度お試しください。\n\(statusCodeError._domain), \(statusCodeError._code)"
+                } else {
+                    title = "システムエラー"
+                    message = "再度お試しください。\n\(statusCodeError._domain), \(statusCodeError._code)"
+                }
 
             case .response(let error):
                 title = "ネットワークエラー"

--- a/iOSEngineerCodeCheckUITests/SearchGitHubRepositoriesUITests.swift
+++ b/iOSEngineerCodeCheckUITests/SearchGitHubRepositoriesUITests.swift
@@ -38,7 +38,12 @@ final class SearchGitHubRepositoriesUITests: XCTestCase {
         let searchField = app.searchFields.firstMatch
         searchField.tap()
         searchField.typeText("Alamofire")
-        app.buttons["search"].tap()
+
+        if app.buttons["search"].exists {
+            app.buttons["search"].tap()
+        } else if app.buttons["検索"].exists {
+            app.buttons["検索"].tap()
+        }
 
         // 検索ボタンを押した直後は初回表示のセルが残っているので少し待つ
         _ = app.waitForExistence(timeout: 2)
@@ -57,7 +62,12 @@ final class SearchGitHubRepositoriesUITests: XCTestCase {
         let searchField = app.searchFields.firstMatch
         searchField.tap()
         searchField.typeText("あeueｗぃえ")
-        app.buttons["search"].tap()
+
+        if app.buttons["search"].exists {
+            app.buttons["search"].tap()
+        } else if app.buttons["検索"].exists {
+            app.buttons["検索"].tap()
+        }
 
         // 検索ボタンを押した直後は初回表示のセルが残っているので少し待つ
         _ = app.waitForExistence(timeout: 2)
@@ -75,7 +85,12 @@ final class SearchGitHubRepositoriesUITests: XCTestCase {
         let searchField = app.searchFields.firstMatch
         searchField.tap()
         searchField.typeText("    ")
-        app.buttons["search"].tap()
+
+        if app.buttons["search"].exists {
+            app.buttons["search"].tap()
+        } else if app.buttons["検索"].exists {
+            app.buttons["検索"].tap()
+        }
 
         // 検索ボタンを押した直後は初回表示のセルが残っているので少し待つ
         _ = app.waitForExistence(timeout: 2)


### PR DESCRIPTION
## 概要
- 検索で空白等を入力して検索すると422エラーとなるので、専用のエラーメッセージを用意する

## 実装
- `RepositorySearchViewPresenter`にて422のエラーだった場合、
エラーメッセージを
「バリデーションエラー\n入力に利用できない文字が含まれています。\n入力を変更して再度お試しください。」
にする
- UITest時にキーボードの言語が日本語だった場合、`buttons["search"].tap()`でfailしてしまうので、存在を確認した上で`buttons["search"].tap()`か`button["検索"].tap()`かを切り替えるようにする
    - UITestを用いてデバッグしていて判明した

<image width=300 src="https://user-images.githubusercontent.com/44288050/139118468-6749827a-327e-4ee7-994a-61cd1c29f788.png">


