### PR TITLE
一覧セルの影の色をprepareForReuseで設定するように修正

### DIFF
--- a/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/Component/RepositoryTableViewCell.swift
+++ b/iOSEngineerCodeCheck/UI/Screen/RepositorySearch/Component/RepositoryTableViewCell.swift
@@ -36,6 +36,17 @@ final class RepositoryTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var languageIconImageView: UIImageView!
     @IBOutlet private weak var languageLabel: UILabel!
+
+    // MARK: - Lifecycle
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        // 実行中にdark/lightテーマを切り替えた場合
+        // UIColor.systemGray3.cgColorがCellを初期化した時と違う色になるため
+        // reuseするたびに設定し直す
+        cardView.layer.shadowColor = UIColor.systemGray3.cgColor
+    }
 }
 
 // MARK: - NibInstantiatable


### PR DESCRIPTION
## 概要
- 一覧セルの影の色をprepareForReuseで設定するように修正
- 実行中にdark/lightテーマを切り替えた場合
`UIColor.systemGray3.cgColor`がCellを初期化した時と違う色になるため
reuseするたびに設定し直す